### PR TITLE
Adding anchors so the ::vault::install class is contained

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,5 +26,4 @@ class vault::config {
     mode    => '0755',
   }
 
-  Class['vault::config'] ~> Class['vault::service']
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,4 +25,6 @@ class vault::config {
     group   => 'root',
     mode    => '0755',
   }
+
+  Class['vault::config'] ~> Class['vault::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,8 +49,10 @@ class vault (
 ) inherits ::vault::params {
   validate_hash($config_hash)
 
+  anchor { '::vault::begin': }  ->
   class { '::vault::install': } ->
-  class { '::vault::config': } ~>
+  class { '::vault::config': }  ~>
   class { '::vault::service': } ->
-  Class['::vault']
+  Class['::vault']              ->
+  anchor { '::vault::end': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,4 +53,7 @@ class vault (
   contain vault::config
   contain vault::service
 
+  Class['vault::install'] -> Class['vault::config']
+  Class['vault::config'] ~> Class['vault::service']
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,10 +49,8 @@ class vault (
 ) inherits ::vault::params {
   validate_hash($config_hash)
 
-  anchor { '::vault::begin': }  ->
-  class { '::vault::install': } ->
-  class { '::vault::config': }  ~>
-  class { '::vault::service': } ->
-  Class['::vault']              ->
-  anchor { '::vault::end': }
+  contain vault::install
+  contain vault::config
+  contain vault::service
+
 }


### PR DESCRIPTION
@jsok 

I've been running into an error installing Vault with this code -- the `::vault::install` steps happen before anything else (including bootstrapping my machine and running `apt-get update`.

This fix properly contains the `::vault::*` classes so they can be properly ordered.

Thanks!
