### PR TITLE
Provide a mechanism for using different service providers (upstart vs systemd)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,9 @@
 # * `service_name`
 #   Customise the name of the system service
 #
+# * `service_provider`
+#   Customise the name of the system service provider
+#
 # * `config_hash`
 #   A hash representing vault's config (in JSON) as per:
 #   https://vaultproject.io/docs/config/index.html
@@ -44,6 +47,7 @@ class vault (
   $purge_config_dir = true,
   $download_url     = $::vault::params::download_url,
   $service_name     = $::vault::params::service_name,
+  $service_provider = $::vault::params::service_provider,
   $config_hash      = {},
   $service_options  = '',
 ) inherits ::vault::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,4 +10,5 @@ class vault::params {
   $config_dir   = '/etc/vault'
   $download_url = 'https://dl.bintray.com/mitchellh/vault/vault_0.3.1_linux_amd64.zip'
   $service_name = 'vault'
+  $service_provider = 'upstart'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,6 @@ class vault::service {
   service { $::vault::service_name:
     ensure   => running,
     enable   => true,
-    provider => 'upstart',
+    provider => $::vault::service_provider,
   }
 }


### PR DESCRIPTION
I ran headlong into this just now. Modern versions of Debian and Ubuntu have systemd as their service provider, instead of upstart. I added things to make that configurable while still defaulting to upstart.
