### PR TITLE
systemd support and a bunch of other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module is currently only tested on:
 
  * Ubuntu 14.04.
  * CentOS/RedHat 6
+ * CentOS/RedHat 7
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -80,4 +80,9 @@ To run RSpec unit tests: ``bundle exec rake spec``
 
 To run RSpec unit tests, puppet-lint, syntax checks and metadata lint: ``bundle exec rake test``
 
-To run Beaker acceptance tests for an Ubuntu Docker container: ``BEAKER_set=ubuntu-14.04-x86_64-docker bundle exec rake acceptance``
+To run Beaker acceptance tests: ``BEAKER_set=<nodeset name> bundle exec rake acceptance``
+where ``<nodeset name>`` is one of the filenames in ``spec/acceptance/nodesets`` without the trailing ``.yml``, specifically one of:
+
+* ``ubuntu-14.04-x86_64-docker``
+* ``centos-6-x86_64-docker``
+* ``centos-7-x86_64-docker``

--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ class { '::vault':
     }
 }
 ```
+
+## Testing
+
+First, ``bundle install``
+
+To run RSpec unit tests: ``bundle exec rake spec``
+
+To run RSpec unit tests, puppet-lint, syntax checks and metadata lint: ``bundle exec rake test``
+
+To run Beaker acceptance tests for an Ubuntu Docker container: ``BEAKER_set=ubuntu-14.04-x86_64-docker bundle exec rake acceptance``

--- a/Rakefile
+++ b/Rakefile
@@ -43,14 +43,10 @@ task :contributors do
   system("git log --format='%aN' | sort -u > CONTRIBUTORS")
 end
 
-task :metadata do
-  sh "metadata-json-lint metadata.json"
-end
-
 desc "Run syntax, lint, and spec tests."
 task :test => [
   :syntax,
   :lint,
   :spec,
-  :metadata,
+  :metadata_lint,
 ]

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,15 +29,6 @@ class vault::config {
         mode    => '0755',
       }
     }
-    'init': {
-       file { '/etc/init.d/vault':
-         ensure  => file,
-         owner   => 'root',
-         group   => 'root',
-         mode    => '0755',
-         content => template('vault/vault.initd.erb'),
-       }
-    }
     'systemd': {
       file { '/etc/systemd/system/vault.service':
         ensure  => file,
@@ -54,6 +45,15 @@ class vault::config {
           user        => 'root',
           refreshonly => true,
         }
+      }
+    }
+    'redhat': {
+      file { '/etc/init.d/vault':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template('vault/vault.initd.erb'),
       }
     }
     default: {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class vault::config {
 case $::osfamily {
   'Debian': {
     file { '/etc/init/vault.conf':
+      ensure  => file,
       mode    => '0444',
       owner   => 'root',
       group   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,24 @@ class vault::config {
          content => template('vault/vault.initd.erb'),
        }
     }
+    'systemd': {
+      file { '/etc/systemd/system/vault.service':
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('vault/vault.systemd.erb'),
+        notify  => Exec['systemd-reload'],
+      }
+      if ! defined(Exec['systemd-reload']) {
+        exec {'systemd-reload':
+          command     => 'systemctl daemon-reload',
+          path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+          user        => 'root',
+          refreshonly => true,
+        }
+      }
+    }
     default: {
       fail("vault::service_provider '${::vault::service_provider}' is not valid")
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ case $::osfamily {
      }
   }
   default: {
-    fail("Module ${module_name} is not supported on ${::osfamily}")
+    fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
   }
 }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,35 +12,35 @@ class vault::config {
     content => vault_sorted_json($::vault::config_hash),
   }
 
-case $::osfamily {
-  'Debian': {
-    file { '/etc/init/vault.conf':
-      ensure  => file,
-      mode    => '0444',
-      owner   => 'root',
-      group   => 'root',
-      content => template('vault/vault.upstart.erb'),
+  case $::vault::service_provider {
+    'upstart': {
+      file { '/etc/init/vault.conf':
+        ensure  => file,
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'root',
+        content => template('vault/vault.upstart.erb'),
+      }
+      file { '/etc/init.d/vault':
+        ensure  => link,
+        target  => '/lib/init/upstart-job',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+      }
     }
-    file { '/etc/init.d/vault':
-      ensure  => link,
-      target  => '/lib/init/upstart-job',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755',
+    'init': {
+       file { '/etc/init.d/vault':
+         ensure  => file,
+         owner   => 'root',
+         group   => 'root',
+         mode    => '0755',
+         content => template('vault/vault.initd.erb'),
+       }
+    }
+    default: {
+      fail("vault::service_provider '${::vault::service_provider}' is not valid")
     }
   }
-  'RedHat': {
-     file { '/etc/init.d/vault':
-       ensure  => file,
-       owner   => 'root',
-       group   => 'root',
-       mode    => '0755',
-       content => template('vault/vault.initd.erb'),
-     }
-  }
-  default: {
-    fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
-  }
-}
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,8 @@
 #   Customise the name of the system service
 #
 # * `service_provider`
-#   Customise the name of the system service provider
+#   Customise the name of the system service provider; this
+#   also controls the init configuration files that are installed.
 #
 # * `config_hash`
 #   A hash representing vault's config (in JSON) as per:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,13 @@
 #   Extra argument to pass to `vault server`, as per:
 #   `vault server --help`
 #
+# * `num_procs`
+#   Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault
+#   can use. The official Vault Terraform install.sh script sets this to the
+#   output of ``nprocs``, with the comment, "Make sure to use all our CPUs,
+#   because Vault can block a scheduler thread". Default: number of CPUs
+#   on the system, retrieved from the ``processorcount`` Fact.
+#
 class vault (
   $user             = $::vault::params::user,
   $manage_user      = $::vault::params::manage_user,
@@ -59,6 +66,7 @@ class vault (
   $service_provider = $::vault::params::service_provider,
   $config_hash      = {},
   $service_options  = '',
+  $num_procs        = $::vault::params::num_procs,
 ) inherits ::vault::params {
   validate_hash($config_hash)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class vault::params {
   $config_dir       = '/etc/vault'
   $download_url     = 'https://releases.hashicorp.com/vault/0.5.1/vault_0.5.1_linux_amd64.zip'
   $service_name     = 'vault'
+  $num_procs        = $::processorcount
 
   case $::osfamily {
     'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,11 @@ class vault::params {
       $service_provider = 'upstart'
     }
     'RedHat': {
-      $service_provider = 'init'
+      if ($::operatingsystemmajrelease == '5' or $::operatingsystemmajrelease == '6') {
+        $service_provider = 'init'
+      } else {
+        $service_provider = 'systemd'
+      }
     }
     default: {
       fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,9 +12,16 @@ class vault::params {
   $config_dir       = '/etc/vault'
   $download_url     = 'https://releases.hashicorp.com/vault/0.5.1/vault_0.5.1_linux_amd64.zip'
   $service_name     = 'vault'
-  $service_provider = $osfamily ? {
-    'Debian'  => 'upstart',
-    'RedHat'  => 'init',
-    default   => 'upstart',
+
+  case $::osfamily {
+    'Debian': {
+      $service_provider = 'upstart'
+    }
+    'RedHat': {
+      $service_provider = 'init'
+    }
+    default: {
+      fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,8 +18,8 @@ class vault::params {
       $service_provider = 'upstart'
     }
     'RedHat': {
-      if ($::operatingsystemmajrelease == '5' or $::operatingsystemmajrelease == '6') {
-        $service_provider = 'init'
+      if ($::operatingsystemmajrelease == '6') {
+        $service_provider = 'redhat'
       } else {
         $service_provider = 'systemd'
       }

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6.6"
+          "6.0",
+          "7.0"
       ]
     }
   ]

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -28,13 +28,19 @@ describe 'vault class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe file('/usr/local/bin/vault') do
-      it { is_expected.to exist }
+    if (fact('osfamily') == 'Debian')
+      describe file('/usr/local/bin/vault') do
+        it { is_expected.to exist }
+      end
     end
 
     describe service('vault') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
+    end
+
+    describe port(8200) do
+      it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
     end
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -22,16 +22,81 @@ describe 'vault class' do
         }
       }
       EOS
-
       # Run it twice and test for idempotency
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes  => true)
     end
 
+    describe user('vault') do
+      it { is_expected.to exist }
+    end
+
+    describe group('vault') do
+      it { is_expected.to exist }
+    end
+
+    describe command('getcap /usr/local/bin/vault') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to include '/usr/local/bin/vault = cap_ipc_lock+ep' }
+    end
+
+    describe file('/usr/local/bin/vault') do
+      it { is_expected.to exist }
+      it { is_expected.to be_mode 555 }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+    end
+
     if (fact('osfamily') == 'Debian')
-      describe file('/usr/local/bin/vault') do
-        it { is_expected.to exist }
+      describe file('/etc/init/vault.conf') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_mode 444 }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+        its(:content) { is_expected.to include 'env VAULT=/usr/local/bin/vault' }
+        its(:content) { is_expected.to include 'env CONFIG=/etc/vault/config.json' }
+        its(:content) { is_expected.to include 'env USER=vault' }
+        its(:content) { is_expected.to include 'env GROUP=vault' }
+        its(:content) { is_expected.to include 'exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG ' }
       end
+      describe file('/etc/init.d/vault') do
+        it { is_expected.to be_symlink }
+        it { is_expected.to be_linked_to '/lib/init/upstart-job' }
+      end
+    elsif (fact('osfamily') == 'RedHat')
+      if (fact('operatingsystemmajrelease') == '6')
+        describe file('/etc/init.d/vault') do
+          it { is_expected.to be_file }
+          it { is_expected.to be_mode 755 }
+          it { is_expected.to be_owned_by 'root' }
+          it { is_expected.to be_grouped_into 'root' }
+          its(:content) { is_expected.to include 'daemon --user vault "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"' }
+          its(:content) { is_expected.to include 'conffile="/etc/vault/config.json"' }
+          its(:content) { is_expected.to include 'exec="/usr/local/bin/vault"' }
+        end
+      else
+        describe file('/etc/systemd/system/vault.service') do
+          it { is_expected.to be_file }
+          it { is_expected.to be_mode 644 }
+          it { is_expected.to be_owned_by 'root' }
+          it { is_expected.to be_grouped_into 'root' }
+          its(:content) { is_expected.to include 'User=vault' }
+          its(:content) { is_expected.to include 'Group=vault' }
+          its(:content) { is_expected.to include 'ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json ' }
+        end
+        describe command('systemctl list-units') do
+          its(:stdout) { is_expected.to include 'vault.service' }
+        end
+      end
+    end
+
+    describe file('/etc/vault') do
+      it { is_expected.to be_directory }
+    end
+
+    describe file('/etc/vault/config.json') do
+      it { is_expected.to be_file }
+      its(:content) { should include '"address":"127.0.0.1:8200"' }
     end
 
     describe service('vault') do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -58,6 +58,7 @@ describe 'vault class' do
         its(:content) { is_expected.to include 'env USER=vault' }
         its(:content) { is_expected.to include 'env GROUP=vault' }
         its(:content) { is_expected.to include 'exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG ' }
+        its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
       end
       describe file('/etc/init.d/vault') do
         it { is_expected.to be_symlink }
@@ -73,6 +74,7 @@ describe 'vault class' do
           its(:content) { is_expected.to include 'daemon --user vault "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"' }
           its(:content) { is_expected.to include 'conffile="/etc/vault/config.json"' }
           its(:content) { is_expected.to include 'exec="/usr/local/bin/vault"' }
+          its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
         end
       else
         describe file('/etc/systemd/system/vault.service') do
@@ -83,6 +85,7 @@ describe 'vault class' do
           its(:content) { is_expected.to include 'User=vault' }
           its(:content) { is_expected.to include 'Group=vault' }
           its(:content) { is_expected.to include 'ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json ' }
+          its(:content) { is_expected.to match /Environment=GOMAXPROCS=\d+/ }
         end
         describe command('systemctl list-units') do
           its(:stdout) { is_expected.to include 'vault.service' }

--- a/spec/acceptance/nodesets/centos-6-x86_64-docker.yml
+++ b/spec/acceptance/nodesets/centos-6-x86_64-docker.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos-6-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: el-6-x86_64
+    hypervisor : docker
+    # Need upstart to tests services
+    image: centos:6
+    # This stops the image from being deleted on completion, speeding up the process.
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y unzip'
+CONFIG:
+  type: foss
+  log_level: debug
+  docker_options:
+    ssl_verify_peer: false

--- a/spec/acceptance/nodesets/centos-7-x86_64-docker.yml
+++ b/spec/acceptance/nodesets/centos-7-x86_64-docker.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos-7-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: el-7-x86_64
+    hypervisor : docker
+    # Need upstart to tests services
+    image: centos:7
+    # This stops the image from being deleted on completion, speeding up the process.
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y unzip iproute'
+CONFIG:
+  type: foss
+  log_level: debug
+  docker_options:
+    ssl_verify_peer: false

--- a/spec/acceptance/nodesets/centos-7-x86_64-docker.yml
+++ b/spec/acceptance/nodesets/centos-7-x86_64-docker.yml
@@ -10,6 +10,7 @@ HOSTS:
     # This stops the image from being deleted on completion, speeding up the process.
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
+    # we need iproute because ServerSpec on CentOS 7 uses the ``ss`` command
     docker_image_commands:
       - 'yum install -y unzip iproute'
 CONFIG:

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -103,7 +103,14 @@ describe 'vault' do
       :osfamily => "RedHat",
     }}
     context 'includes SysV init script' do
-      it { is_expected.to contain_file('/etc/init.d/vault').with_mode('0755') }
+      it {
+        is_expected.to contain_file('/etc/init.d/vault')
+          .with_mode('0755')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_content(/^#!\/bin\/bash/)
+      }
     end
   end
   context 'Debian-specific' do

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -2,23 +2,13 @@ require 'spec_helper'
 
 describe 'vault' do
   ['RedHat','Debian'].each do |osfamily|
-    if osfamily == 'Debian'
+    context "on #{osfamily}" do
       let(:facts) {{
-        :path => '/usr/local/bin:/usr/bin:/bin',
-        :osfamily => 'Debian',
+        :path     => '/usr/local/bin:/usr/bin:/bin',
+        :osfamily => "#{osfamily}",
       }}
-    end
 
-    if osfamily == 'RedHat'
-      let(:facts) {{
-        :path => '/usr/local/bin:/usr/bin:/bin',
-        :osfamily => 'RedHat',
-      }}
-    end
-
-
-    if osfamily == 'RedHat' || osfamily== 'Debian'
-      context "vault class without any parameters" do
+      context "vault class with simple config_hash only" do
         let(:params) {{
           :config_hash => {
             'advertise_addr' => '0.0.0.0',
@@ -37,6 +27,7 @@ describe 'vault' do
         }}
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('vault') }
 
         it { is_expected.to contain_class('vault::params') }
         it { is_expected.to contain_class('vault::install').that_comes_before('vault::config') }
@@ -71,72 +62,107 @@ describe 'vault' do
             .with_content(/"tls_disable":\s*1/)
         }
 
-        it { is_expected.to contain_file('/etc/init/vault.conf').with_mode('0444') }
-        it {
-          is_expected.to contain_file('/etc/init.d/vault')
-             .with_ensure('link')
-             .with_target('/lib/init/upstart-job')
-             .with_mode('0755')
-        }
-
         it { is_expected.to contain_file('/usr/local/bin/vault').with_mode('0555') }
         it {
           is_expected.to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault')
             .with_refreshonly('true')
             .that_subscribes_to('File[/usr/local/bin/vault]')
         }
-      end
 
-      context "disable mlock" do
-        let(:params) {{
-          'config_hash' => {
-            'disable_mlock' => true
+        context "disable mlock" do
+          let(:params) {{
+            'config_hash' => {
+              'disable_mlock' => true
+            }
+          }}
+          it { is_expected.not_to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault') }
+
+          it {
+            is_expected.to contain_file('/etc/vault/config.json')
+              .with_content(/"disable_mlock":\s*true/)
           }
-        }}
-        it { is_expected.not_to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault') }
+        end
 
-        it {
-          is_expected.to contain_file('/etc/vault/config.json')
-            .with_content(/"disable_mlock":\s*true/)
-        }
-      end
+        context "installs from download url" do
+          let(:params) {{
+            :download_url => 'http://example.com/vault.zip',
+          }}
 
-      context "installs from download url" do
-        let(:params) {{
-          :download_url => 'http://example.com/vault.zip',
-        }}
-
-        it {
-          is_expected.to contain_staging__deploy('vault.zip')
-            .with_source('http://example.com/vault.zip')
-            .that_notifies('File[/usr/local/bin/vault]')
-        }
-      end
-
-      context "service with modified options" do
-        let(:params) {{
-          :bin_dir => '/opt/bin',
-          :config_dir => '/opt/etc/vault',
-          :service_options => '-log-level=info',
-          :user => 'root',
-          :group => 'admin',
-        }}
-        it {
-          is_expected.to contain_file('/etc/init/vault.conf')
-            .with_content(/env USER=root/)
-            .with_content(/env GROUP=admin/)
-            .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
-            .with_content(/env VAULT=\/opt\/bin\/vault/)
-            .with_content(/start-stop-daemon .* -log-level=info$/)
-        }
+          it {
+            is_expected.to contain_staging__deploy('vault.zip')
+              .with_source('http://example.com/vault.zip')
+              .that_notifies('File[/usr/local/bin/vault]')
+          }
+        end
       end
     end
-
-    if osfamily == 'RedHat'
-      context "installs from download url" do
-        it { is_expected.to contain_file('/etc/init.d/vault').with_mode('0755') }
-      end
+  end
+  context 'RedHat-specific' do
+    let(:facts) {{
+      :path     => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily => "RedHat",
+    }}
+    context 'includes SysV init script' do
+      it { is_expected.to contain_file('/etc/init.d/vault').with_mode('0755') }
     end
-    
+  end
+  context 'Debian-specific' do
+    let(:facts) {{
+      :path     => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily => "Debian",
+    }}
+    context 'includes init link to upstart-job' do
+      it {
+        is_expected.to contain_file('/etc/init.d/vault')
+           .with_ensure('link')
+           .with_target('/lib/init/upstart-job')
+           .with_mode('0755')
+      }
+    end
+    context 'contains /etc/init/vault.conf' do
+      it { is_expected.to contain_file('/etc/init/vault.conf').with_mode('0444') }
+    end
+    context "service with modified options" do
+      let(:params) {{
+        :bin_dir => '/opt/bin',
+        :config_dir => '/opt/etc/vault',
+        :service_options => '-log-level=info',
+        :user => 'root',
+        :group => 'admin',
+      }}
+      it {
+        is_expected.to contain_file('/etc/init/vault.conf')
+          .with_content(/env USER=root/)
+          .with_content(/env GROUP=admin/)
+          .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
+          .with_content(/env VAULT=\/opt\/bin\/vault/)
+          .with_content(/start-stop-daemon .* -log-level=info$/)
+      }
+      it {
+        is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
+          .with_refreshonly('true')
+          .that_subscribes_to('File[/opt/bin/vault]')
+      }
+      it { is_expected.to contain_file('/opt/etc/vault/config.json') }
+
+      it { is_expected.to contain_file('/opt/bin/vault').with_mode('0555') }
+      it {
+        is_expected.to contain_file('/opt/etc/vault')
+          .with_ensure('directory')
+          .with_purge('true') \
+          .with_recurse('true')
+      }
+      it { is_expected.to contain_user('root') }
+      it { is_expected.to contain_group('admin') }
+    end
+  end
+  context 'on unsupported osfamily' do
+    let(:facts) {{
+      :path     => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily => 'nexenta',
+    }}
+    it {
+      expect { should contain_class('vault') }.to raise_error(Puppet::Error, /Module vault is not supported on osfamily 'nexenta'/)
+    }
   end
 end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -127,7 +127,14 @@ describe 'vault' do
       }
     end
     context 'contains /etc/init/vault.conf' do
-      it { is_expected.to contain_file('/etc/init/vault.conf').with_mode('0444') }
+      it {
+        is_expected.to contain_file('/etc/init/vault.conf')
+        .with_mode('0444')
+        .with_ensure('file')
+        .with_owner('root')
+        .with_group('root')
+        .with_content(/^# vault Agent \(Upstart unit\)/)
+      }
     end
     context "service with modified options" do
       let(:params) {{

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -4,8 +4,9 @@ describe 'vault' do
   ['RedHat','Debian'].each do |osfamily|
     context "on #{osfamily}" do
       let(:facts) {{
-        :path     => '/usr/local/bin:/usr/bin:/bin',
-        :osfamily => "#{osfamily}",
+        :path           => '/usr/local/bin:/usr/bin:/bin',
+        :osfamily       => "#{osfamily}",
+        :processorcount => '3',
       }}
 
       context "vault class with simple config_hash only" do
@@ -105,6 +106,7 @@ describe 'vault' do
       :path                      => '/usr/local/bin:/usr/bin:/bin',
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '6',
+      :processorcount            => '3',
     }}
     context 'includes SysV init script' do
       it {
@@ -114,7 +116,7 @@ describe 'vault' do
           .with_owner('root')
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
           .with_content(%r{daemon --user vault "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-""})
           .with_content(%r{exec="/usr/local/bin/vault"})
@@ -129,6 +131,7 @@ describe 'vault' do
         :service_options => '-log-level=info',
         :user => 'root',
         :group => 'admin',
+        :num_procs => '5',
       }}
       it {
         is_expected.to contain_file('/etc/init.d/vault')
@@ -137,7 +140,7 @@ describe 'vault' do
           .with_owner('root')
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
           .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
           .with_content(%r{exec="/opt/bin/vault"})
@@ -156,6 +159,7 @@ describe 'vault' do
       :path                      => '/usr/local/bin:/usr/bin:/bin',
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '7',
+      :processorcount            => '3',
     }}
     context 'includes systemd init script' do
       it {
@@ -168,7 +172,7 @@ describe 'vault' do
           .with_content(/^# vault systemd unit file/)
           .with_content(/^User=vault$/)
           .with_content(/^Group=vault$/)
-          .with_content(/Environment=GOMAXPROCS=2/)
+          .with_content(/Environment=GOMAXPROCS=3/)
           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
           .with_content(/SecureBits=keep-caps/)
           .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
@@ -183,6 +187,7 @@ describe 'vault' do
         :service_options => '-log-level=info',
         :user => 'root',
         :group => 'admin',
+        :num_procs => 8,
       }}
       it {
         is_expected.to contain_file('/etc/systemd/system/vault.service')
@@ -194,7 +199,7 @@ describe 'vault' do
           .with_content(/^# vault systemd unit file/)
           .with_content(/^User=root$/)
           .with_content(/^Group=admin$/)
-          .with_content(/Environment=GOMAXPROCS=2/)
+          .with_content(/Environment=GOMAXPROCS=8/)
           .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
       }
     end
@@ -245,8 +250,9 @@ describe 'vault' do
   end
   context 'Debian-specific' do
     let(:facts) {{
-      :path     => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily => 'Debian',
+      :path           => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily       => 'Debian',
+      :processorcount => '3',
     }}
     context 'includes init link to upstart-job' do
       it {
@@ -269,7 +275,7 @@ describe 'vault' do
         .with_content(/env CONFIG=\/etc\/vault\/config.json/)
         .with_content(/env VAULT=\/usr\/local\/bin\/vault/)
         .with_content(/exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $/)
-        .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
+        .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
       }
     end
     context "service with modified options" do
@@ -311,6 +317,7 @@ describe 'vault' do
       :path                      => '/usr/local/bin:/usr/bin:/bin',
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => 6,
+      :processorcount            => '3',
     }}
     let(:params) {{
       :service_provider => 'foo',
@@ -324,8 +331,9 @@ describe 'vault' do
   end
   context 'on unsupported osfamily' do
     let(:facts) {{
-      :path     => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily => 'nexenta',
+      :path           => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily       => 'nexenta',
+      :processorcount => '3',
     }}
     it {
       expect { should contain_class('vault') }.to raise_error(Puppet::Error, /Module vault is not supported on osfamily 'nexenta'/)

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -114,6 +114,7 @@ describe 'vault' do
           .with_owner('root')
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
           .with_content(%r{daemon --user vault "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-""})
           .with_content(%r{exec="/usr/local/bin/vault"})
@@ -136,6 +137,7 @@ describe 'vault' do
           .with_owner('root')
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
           .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
           .with_content(%r{exec="/opt/bin/vault"})
@@ -166,6 +168,7 @@ describe 'vault' do
           .with_content(/^# vault systemd unit file/)
           .with_content(/^User=vault$/)
           .with_content(/^Group=vault$/)
+          .with_content(/Environment=GOMAXPROCS=2/)
           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
           .with_content(/SecureBits=keep-caps/)
           .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
@@ -191,6 +194,7 @@ describe 'vault' do
           .with_content(/^# vault systemd unit file/)
           .with_content(/^User=root$/)
           .with_content(/^Group=admin$/)
+          .with_content(/Environment=GOMAXPROCS=2/)
           .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
       }
     end
@@ -265,6 +269,7 @@ describe 'vault' do
         .with_content(/env CONFIG=\/etc\/vault\/config.json/)
         .with_content(/env VAULT=\/usr\/local\/bin\/vault/)
         .with_content(/exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $/)
+        .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-2}/)
       }
     end
     context "service with modified options" do

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -97,10 +97,11 @@ describe 'vault' do
       end
     end
   end
-  context 'RedHat-specific' do
+  context 'RedHat 6 specific' do
     let(:facts) {{
-      :path     => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily => "RedHat",
+      :path                      => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily                  => 'RedHat',
+      :operatingsystemmajrelease => 6,
     }}
     context 'includes SysV init script' do
       it {
@@ -116,7 +117,7 @@ describe 'vault' do
   context 'Debian-specific' do
     let(:facts) {{
       :path     => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily => "Debian",
+      :osfamily => 'Debian',
     }}
     context 'includes init link to upstart-job' do
       it {
@@ -168,6 +169,22 @@ describe 'vault' do
       }
       it { is_expected.to contain_user('root') }
       it { is_expected.to contain_group('admin') }
+    end
+  end
+  context 'Invalid service_provider' do
+    let(:facts) {{
+      :path                      => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily                  => 'RedHat',
+      :operatingsystemmajrelease => 6,
+    }}
+    let(:params) {{
+      :service_provider => 'foo',
+    }}
+    context 'fails with a helpful message' do
+      it {
+        expect { should contain_class('vault::config') }
+          .to raise_error(Puppet::Error, /vault::service_provider 'foo' is not valid/)
+      }
     end
   end
   context 'on unsupported osfamily' do

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -167,6 +167,10 @@ describe 'vault' do
           .with_content(/^User=vault$/)
           .with_content(/^Group=vault$/)
           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+          .with_content(/SecureBits=keep-caps/)
+          .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+          .with_content(/NoNewPrivileges=yes/)
       }
     end
     context 'service with non-default options' do
@@ -188,6 +192,41 @@ describe 'vault' do
           .with_content(/^User=root$/)
           .with_content(/^Group=admin$/)
           .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+      }
+    end
+    context 'with mlock disabled' do
+      let(:params) {{
+        :config_hash => {
+          'disable_mlock'  => true,
+          'advertise_addr' => '0.0.0.0',
+          'backend' => {
+            'file' => {
+              'path' => '/data/vault'
+            }
+          },
+          'listener' => {
+            'tcp' => {
+              'address'     => '127.0.0.1:8200',
+              'tls_disable' => 1,
+            }
+          }
+        }
+      }}
+      it {
+        is_expected.to contain_file('/etc/systemd/system/vault.service')
+          .with_mode('0644')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_notify('Exec[systemd-reload]')
+          .with_content(/^# vault systemd unit file/)
+          .with_content(/^User=vault$/)
+          .with_content(/^Group=vault$/)
+          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+          .without_content(/SecureBits=keep-caps/)
+          .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+          .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
+          .with_content(/NoNewPrivileges=yes/)
       }
     end
     context 'includes systemd reload' do

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -1,52 +1,119 @@
-#!/bin/bash
+#!/bin/sh
 #
-# Basic startup script for the Vault Project Server
+# vault - this script manages the vault server
 #
 # chkconfig: 3 85 15
-# description: Init.d script for Vault Project Server
 # processname: vault
+# description: Init.d script for Vault Project Server
 # pidfile: /var/run/vault.pid
 # config: <%= scope.lookupvar('vault::config_dir') %>/config.json
-#
 ###########################################################################################################
 # this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
 # any changes will be overwritten if Puppet is run again
 ###########################################################################################################
 
-prog='Vault Server'
-RETVAL=0
+### BEGIN INIT INFO
+# Provides:       vault
+# Required-Start: $local_fs $network
+# Required-Stop:  $local_fs $network
+# Default-Start: 3 4 5
+# Default-Stop:  0 1 2 6
+# Short-Description: Manage the vault server
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+# Check that networking is up.
+[ "$NETWORKING" = "no" ] && exit 0
+
+exec="<%= scope.lookupvar('vault::bin_dir') %>/vault"
+prog=${exec##*/}
+
+lockfile="/var/lock/subsys/$prog"
+pidfile="/var/run/${prog}.pid"
+logfile="/var/log/${prog}.log"
+sysconfig="/etc/sysconfig/$prog"
+conffile="<%= scope.lookupvar('vault::config_dir') %>/config.json"
+
+[ -f $sysconfig ] && . $sysconfig
+
+OPTIONS=$OPTIONS:-"<%= scope.lookupvar('vault::service_options') %>"
 
 start() {
-  echo -n $"Starting $prog: "
-  su <%= scope.lookupvar('vault::user') %> -c '<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %> >/dev/null 2>&1 &'
-  RETVAL=$?
-  echo
-  [ $RETVAL = 0 ] && touch /var/lock/subsys/vault
-  return $RETVAL
+    [ -x $exec ] || exit 5
+    [ -f $conffile ] || exit 6
+
+    echo -n $"Starting $prog: "
+    touch $logfile $pidfile
+    chown <%= scope.lookupvar('vault::user') %> $logfile $pidfile
+    daemon --user <%= scope.lookupvar('vault::user') %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
+
+    RETVAL=$?
+    if [ $RETVAL -eq 0 ]; then
+        touch $lockfile
+    fi
+    echo
+    return $RETVAL
 }
 
 stop() {
-  echo -n $"Stopping $prog: "
-  killall vault
-  RETVAL=$?
-  echo
-  [ $RETVAL = 0 ] && rm -f /var/lock/subsys/vault /var/run/vault.pid
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $exec 2>> $logfile
+    RETVAL=$?
+    [ $RETVAL -eq 0 ] && rm -f $lockfile
+    echo
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p $pidfile $exec -HUP
+    echo
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
 }
 
 case "$1" in
-  start)
-    start
-    ;;
-  stop)
-    stop
-    ;;
-  restart)
-    stop
-    start
-    ;;
-  *)
-    echo $"Usage: $prog {start|restart|stop}"
-    exit 1
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 7
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
 esac
 
-exit $RETVAL
+exit $?

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -7,6 +7,11 @@
 # processname: vault
 # pidfile: /var/run/vault.pid
 # config: <%= scope.lookupvar('vault::config_dir') %>/config.json
+#
+###########################################################################################################
+# this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
+# any changes will be overwritten if Puppet is run again
+###########################################################################################################
 
 prog='Vault Server'
 RETVAL=0

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -50,6 +50,7 @@ start() {
     echo -n $"Starting $prog: "
     touch $logfile $pidfile
     chown <%= scope.lookupvar('vault::user') %> $logfile $pidfile
+    export GOMAXPROCS=${GOMAXPROCS:-2}
     daemon --user <%= scope.lookupvar('vault::user') %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -50,7 +50,7 @@ start() {
     echo -n $"Starting $prog: "
     touch $logfile $pidfile
     chown <%= scope.lookupvar('vault::user') %> $logfile $pidfile
-    export GOMAXPROCS=${GOMAXPROCS:-2}
+    export GOMAXPROCS=${GOMAXPROCS:-<%= scope.lookupvar('vault::num_procs') %>}
     daemon --user <%= scope.lookupvar('vault::user') %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -1,0 +1,32 @@
+# vault systemd unit file
+###########################################################################################################
+# this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
+# any changes will be overwritten if Puppet is run again
+# This script is originally from: https://github.com/mterron/init-scripts/blob/master/vault.service
+###########################################################################################################
+
+[Unit]
+Description=Vault server
+Requires=basic.target network.target
+After=basic.target network.target
+
+[Service]
+User=<%= scope.lookupvar('vault::user') %>
+Group=<%= scope.lookupvar('vault::group') %>
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+SecureBits=keep-caps
+Capabilities=CAP_IPC_LOCK+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
+KillSignal=SIGINT
+TimeoutStopSec=30s
+Restart=on-failure
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -26,7 +26,7 @@ Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
 <% end -%>
-Environment=GOMAXPROCS=2
+Environment=GOMAXPROCS=<%= scope.lookupvar('vault::num_procs') %>
 ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
 KillSignal=SIGINT
 TimeoutStopSec=30s

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -26,6 +26,7 @@ Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
 <% end -%>
+Environment=GOMAXPROCS=2
 ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
 KillSignal=SIGINT
 TimeoutStopSec=30s

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -17,10 +17,15 @@ PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=read-only
+<% if scope.lookupvar('vault::config_hash')['disable_mlock'] -%>
+CapabilityBoundingSet=CAP_SYSLOG
+NoNewPrivileges=yes
+<% else -%>
 SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
+<% end -%>
 ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
 KillSignal=SIGINT
 TimeoutStopSec=30s

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -1,4 +1,8 @@
 # vault Agent (Upstart unit)
+###########################################################################################################
+# this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
+# any changes will be overwritten if Puppet is run again
+###########################################################################################################
 description "vault server"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -14,7 +14,7 @@ env GROUP=<%= scope.lookupvar('vault::group') %>
 env PID_FILE=/var/run/vault.pid
 
 script
-    export GOMAXPROCS=${GOMAXPROCS:-2}
+    export GOMAXPROCS=${GOMAXPROCS:-<%= scope.lookupvar('vault::num_procs') %>}
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
     exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope.lookupvar('vault::service_options') %>
 end script


### PR DESCRIPTION
- add systemd support for RedHat 7
- add documentation on how to run acceptance tests
- add centos6 and centos7 acceptance tests
- switch `metadata` Rake task from using deprecated `metadata` task to `metadata_lint`
- refactor how OS-specific things are handled, to make it a bit more consistent with $service_provider
- expose a `num_procs` parameter (GOMAXPROCS) and default it to $::processorcount, per https://github.com/hashicorp/vault/blob/master/terraform/aws/scripts/install.sh.tpl#L38
- add RedHat 7 to supported OSes list in metadata.json
- add all resources to acceptance tests
- add unit tests coverage for all resources, and include interpolated portions of templates
- replace RedHat 6 SysV init script with one that meets the actual RedHat spec
