### PR TITLE
added support for Amazon os

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class vault::params {
       $service_provider = 'upstart'
     }
     'RedHat': {
-      if ($::operatingsystemmajrelease == '6' or $::operatingsystem =~ /^[Aa]mazon$/) {
+      if ($::operatingsystemmajrelease == '6' or $::operatingsystem = 'Amazon') {
         $service_provider = 'redhat'
       } else {
         $service_provider = 'systemd'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class vault::params {
       $service_provider = 'upstart'
     }
     'RedHat': {
-      if ($::operatingsystemmajrelease == '6') {
+      if ($::operatingsystemmajrelease == '6' or $::operatingsystem =~ /^[Aa]mazon$/) {
         $service_provider = 'redhat'
       } else {
         $service_provider = 'systemd'

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,13 @@
       ]
     },
     {
+      "operatingsystem": "Amazon Linux (RHEL based non systemd)",
+      "operatingsystemrelease": [
+          "6.0",
+          "7.0"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
           "6.0",

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -101,6 +101,60 @@ describe 'vault' do
       end
     end
   end
+  context 'RedHat 7 Amazon Linux specific' do
+   let(:facts) {{
+      :path                      => '/usr/local/bin:/usr/bin:/bin',
+      :osfamily                  => 'RedHat',
+      :operatingsystem           => 'Amazon',
+      :operatingsystemmajrelease => '7',
+      :processorcount            => '3',
+   }}
+   context 'includes SysV init script' do
+      it {
+        is_expected.to contain_file('/etc/init.d/vault')
+          .with_mode('0755')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_content(%r{^#!/bin/sh})
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
+          .with_content(%r{daemon --user vault "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
+          .with_content(%r{OPTIONS=\$OPTIONS:-""})
+          .with_content(%r{exec="/usr/local/bin/vault"})
+          .with_content(%r{conffile="/etc/vault/config.json"})
+          .with_content(%r{chown vault \$logfile \$pidfile})
+      }
+    end
+    context 'service with non-default options' do
+      let(:params) {{
+        :bin_dir => '/opt/bin',
+        :config_dir => '/opt/etc/vault',
+        :service_options => '-log-level=info',
+        :user => 'root',
+        :group => 'admin',
+        :num_procs => '5',
+      }}
+      it {
+        is_expected.to contain_file('/etc/init.d/vault')
+          .with_mode('0755')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_content(%r{^#!/bin/sh})
+          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
+          .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
+          .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
+          .with_content(%r{exec="/opt/bin/vault"})
+          .with_content(%r{conffile="/opt/etc/vault/config.json"})
+          .with_content(%r{chown root \$logfile \$pidfile})
+      }
+    end
+    context 'does not include systemd reload' do
+      it {
+        is_expected.to_not contain_exec('systemd-reload')
+      }
+    end
+  end
   context 'RedHat 6 specific' do
     let(:facts) {{
       :path                      => '/usr/local/bin:/usr/bin:/bin',


### PR DESCRIPTION
Added the Amazon RedHat based linux AMI support.
Unfortunately I wasn't able to actually run the spec tests, but I did add one to check if RedHat version 7 with operatingsystem Amazon would indeed not use systemd
