### PR TITLE
Configure log file for upstart.

### DIFF
--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -12,10 +12,12 @@ env CONFIG=<%= scope.lookupvar('vault::config_dir') %>/config.json
 env USER=<%= scope.lookupvar('vault::user') %>
 env GROUP=<%= scope.lookupvar('vault::group') %>
 env PID_FILE=/var/run/vault.pid
+env LOG_FILE=/var/log/vault.log
 
 script
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope.lookupvar('vault::num_procs') %>}
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
+    exec >> $LOG_FILE 2>&1
     exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope.lookupvar('vault::service_options') %>
 end script
 


### PR DESCRIPTION
This PR configures a log file for the upstart configuration similar to the one for the [init.d](https://github.com/jsok/puppet-vault/blob/master/templates/vault.initd.erb#L38) configuration.

I tested this by provisioning a vault server with the new configuration and observing the log file being created and log entries being appended. I restarted the service and the new entries were appended to the existing file.
