### PR TITLE
Add installation from package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ rvm:
 script: bundle exec rake test
 env:
   - PUPPET_GEM_VERSION="~> 3.8.0"
-  - PUPPET_GEM_VERSION="~> 4.0.0"
-  - PUPPET_GEM_VERSION="~> 4.4.0" DEPLOY_CANDIDATE="yes"
+  - PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
+  - PUPPET_GEM_VERSION="~> 4.4" STRICT_VARIABLES="no"
+  - PUPPET_GEM_VERSION="~> 4.6" STRICT_VARIABLES="no" DEPLOY_CANDIDATE="yes"
 matrix:
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
+      env: PUPPET_GEM_VERSION="~> 4.4"
     - rvm: 2.2
       env: PUPPET_GEM_VERSION="~> 3.8.0"
 deploy:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,53 +14,54 @@ class vault::config {
     group   => $::vault::group,
   }
 
-  case $::vault::service_provider {
-    'upstart': {
-      file { '/etc/init/vault.conf':
-        ensure  => file,
-        mode    => '0444',
-        owner   => 'root',
-        group   => 'root',
-        content => template('vault/vault.upstart.erb'),
-      }
-      file { '/etc/init.d/vault':
-        ensure => link,
-        target => '/lib/init/upstart-job',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
-      }
-    }
-    'systemd': {
-      file { '/etc/systemd/system/vault.service':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('vault/vault.systemd.erb'),
-        notify  => Exec['systemd-reload'],
-      }
-      if ! defined(Exec['systemd-reload']) {
-        exec {'systemd-reload':
-          command     => 'systemctl daemon-reload',
-          path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-          user        => 'root',
-          refreshonly => true,
+  if $::vault::install_method == 'archive' {
+    case $::vault::service_provider {
+      'upstart': {
+        file { '/etc/init/vault.conf':
+          ensure  => file,
+          mode    => '0444',
+          owner   => 'root',
+          group   => 'root',
+          content => template('vault/vault.upstart.erb'),
+        }
+        file { '/etc/init.d/vault':
+          ensure => link,
+          target => '/lib/init/upstart-job',
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
         }
       }
-    }
-    'redhat': {
-      file { '/etc/init.d/vault':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0755',
-        content => template('vault/vault.initd.erb'),
+      'systemd': {
+        file { '/etc/systemd/system/vault.service':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => template('vault/vault.systemd.erb'),
+          notify  => Exec['systemd-reload'],
+        }
+        if ! defined(Exec['systemd-reload']) {
+          exec {'systemd-reload':
+            command     => 'systemctl daemon-reload',
+            path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+            user        => 'root',
+            refreshonly => true,
+          }
+        }
+      }
+      'redhat': {
+        file { '/etc/init.d/vault':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755',
+          content => template('vault/vault.initd.erb'),
+        }
+      }
+      default: {
+        fail("vault::service_provider '${::vault::service_provider}' is not valid")
       }
     }
-    default: {
-      fail("vault::service_provider '${::vault::service_provider}' is not valid")
-    }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,8 +68,8 @@ class vault (
   $service_options  = '',
   $num_procs        = $::vault::params::num_procs,
   $install_method   = $::vault::params::install_method,
-  $package_name     = $::vault::package_name,
-  $package_ensure   = $::vault::package_ensure
+  $package_name     = $::vault::params::package_name,
+  $package_ensure   = $::vault::params::package_ensure
 ) inherits ::vault::params {
   validate_hash($config_hash)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,9 @@ class vault (
   $config_hash      = {},
   $service_options  = '',
   $num_procs        = $::vault::params::num_procs,
+  $install_method   = $::vault::params::install_method,
+  $package_name     = $::vault::package_name,
+  $package_ensure   = $::vault::package_ensure
 ) inherits ::vault::params {
   validate_hash($config_hash)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,11 +3,25 @@
 class vault::install {
   $vault_bin = "${::vault::bin_dir}/vault"
 
-  staging::deploy { 'vault.zip':
-    source  => $::vault::download_url,
-    target  => $::vault::bin_dir,
-    creates => $vault_bin,
-  } ~>
+  case $::vault::install_method {
+    'archive': {
+      staging::deploy { 'vault.zip':
+        source  => $::vault::download_url,
+        target  => $::vault::bin_dir,
+        creates => $vault_bin,
+      }
+    }
+
+    'repo': {
+      package { $::vault::package_name:
+        ensure  => $::vault::package_ensure
+      }
+    }
+
+    default: {
+      fail("Installation method ${::vault::install_method} not supported")
+    }
+  }->
   file { $vault_bin:
     owner => 'root',
     group => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@ class vault::install {
         source  => $::vault::download_url,
         target  => $::vault::bin_dir,
         creates => $vault_bin,
+        notify  => File[$vault_bin]
       }
     }
 
@@ -21,7 +22,8 @@ class vault::install {
     default: {
       fail("Installation method ${::vault::install_method} not supported")
     }
-  }->
+  }
+
   file { $vault_bin:
     owner => 'root',
     group => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,9 @@ class vault::params {
   $download_url     = 'https://releases.hashicorp.com/vault/0.6.0/vault_0.6.0_linux_amd64.zip'
   $service_name     = 'vault'
   $num_procs        = $::processorcount
+  $install_method   = 'archive'
+  $package_name     = 'vault'
+  $package_ensure   = 'installed'
 
   case $::osfamily {
     'Debian': {

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -91,7 +91,8 @@ describe 'vault' do
 
         context "installs from download url" do
           let(:params) {{
-            :download_url => 'http://example.com/vault.zip',
+            :download_url   => 'http://example.com/vault.zip',
+            :install_method => 'archive',
           }}
 
           it {
@@ -99,6 +100,16 @@ describe 'vault' do
               .with_source('http://example.com/vault.zip')
               .that_notifies('File[/usr/local/bin/vault]')
           }
+        end
+
+        context "installs from repository" do
+          let(:params) {{
+            :install_method => 'repo',
+            :package_name   => 'vault',
+            :package_ensure => 'installed',
+          }}
+
+          it { should contain_package('vault') }
         end
       end
     end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -329,7 +329,7 @@ describe 'vault' do
     let(:facts) {{
       :path                      => '/usr/local/bin:/usr/bin:/bin',
       :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => 6,
+      :operatingsystemmajrelease => '6',
       :processorcount            => '3',
     }}
     let(:params) {{


### PR DESCRIPTION
New parameter 'installation_method' was added. It is possible to install vault from package. Default configuration remains unchanged.
