### PR TITLE
Specification of download_url made easy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,23 @@
 #   Whether the `config_dir` should be purged before installing the
 #   generated config.
 #
+# * `package_name`
+#   Defaults to vault, used to form the download url
+#   using download_url_base when download_url is undefined.
+#
 # * `download_url`
 #   URL to download the vault zip distribution from.
+#
+# * `download_url_base`
+#   Customised URL base to download the vault zip distribution from.
+#   Defaults to "https://releases.hashicorp.com/vault/"
+#
+# * `download_extension`
+#   Defaults to zip. Used to form the download url
+#   using download_url_base when download_url is undefined.
+#
+# * `version`
+#   Version of vault to download and install. Valid only if download_url is undefined.
 #
 # * `service_name`
 #   Customise the name of the system service
@@ -53,22 +68,38 @@
 #   because Vault can block a scheduler thread". Default: number of CPUs
 #   on the system, retrieved from the ``processorcount`` Fact.
 #
+# * `os`
+#   Defaults to the value of downcase of fact ``kernel``
+#   Used to form the download url using download_url_base when download_url is undefined.
+#
+# * arch
+#   Derieved from fact ``architecture``.
+#   Used to form the download url using download_url_base when download_url is undefined.
+#
 class vault (
-  $user             = $::vault::params::user,
-  $manage_user      = $::vault::params::manage_user,
-  $group            = $::vault::params::group,
-  $manage_group     = $::vault::params::manage_group,
-  $bin_dir          = $::vault::params::bin_dir,
-  $config_dir       = $::vault::params::config_dir,
-  $purge_config_dir = true,
-  $download_url     = $::vault::params::download_url,
-  $service_name     = $::vault::params::service_name,
-  $service_provider = $::vault::params::service_provider,
-  $config_hash      = {},
-  $service_options  = '',
-  $num_procs        = $::vault::params::num_procs,
+  $user               = $::vault::params::user,
+  $manage_user        = $::vault::params::manage_user,
+  $group              = $::vault::params::group,
+  $manage_group       = $::vault::params::manage_group,
+  $bin_dir            = $::vault::params::bin_dir,
+  $config_dir         = $::vault::params::config_dir,
+  $purge_config_dir   = true,
+  $package_name       = $::vault::params::package_name,
+  $download_url       = undef,
+  $download_url_base  = $::vault::params::download_url_base,
+  $download_extension = $::vault::params::download_extension,
+  $version            = $::vault::params::version,
+  $service_name       = $::vault::params::service_name,
+  $service_provider   = $::vault::params::service_provider,
+  $config_hash        = {},
+  $service_options    = '',
+  $num_procs          = $::vault::params::num_procs,
+  $os                 = $::vault::params::os,
+  $arch               = $::vault::params::arch,
 ) inherits ::vault::params {
   validate_hash($config_hash)
+
+  $real_download_url = pick($download_url,"${download_url_base}/${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
 
   contain vault::install
   contain vault::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class vault::install {
   $vault_bin = "${::vault::bin_dir}/vault"
 
   staging::deploy { 'vault.zip':
-    source  => $::vault::download_url,
+    source  => $::vault::real_download_url,
     target  => $::vault::bin_dir,
     creates => $vault_bin,
   } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,15 +4,18 @@
 # It sets variables according to platform.
 #
 class vault::params {
-  $user             = 'vault'
-  $manage_user      = true
-  $group            = 'vault'
-  $manage_group     = true
-  $bin_dir          = '/usr/local/bin'
-  $config_dir       = '/etc/vault'
-  $download_url     = 'https://releases.hashicorp.com/vault/0.6.0/vault_0.6.0_linux_amd64.zip'
-  $service_name     = 'vault'
-  $num_procs        = $::processorcount
+  $user               = 'vault'
+  $manage_user        = true
+  $group              = 'vault'
+  $manage_group       = true
+  $bin_dir            = '/usr/local/bin'
+  $config_dir         = '/etc/vault'
+  $package_name       = 'vault'
+  $download_url_base  = 'https://releases.hashicorp.com/vault/'
+  $download_extension = 'zip'
+  $version            = '0.6.0'
+  $service_name       = 'vault'
+  $num_procs          = $::processorcount
 
   case $::osfamily {
     'Debian': {
@@ -29,4 +32,16 @@ class vault::params {
       fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
     }
   }
+
+  case $::architecture {
+    'x86_64', 'amd64': { $arch = 'amd64' }
+    'i386':            { $arch = '386'   }
+    /^arm.*/:          { $arch = 'arm'   }
+    default:           {
+      fail("Unsupported kernel architecture: ${::architecture}")
+    }
+  }
+
+  $os = downcase($::kernel)
+
 }


### PR DESCRIPTION
Form the download url based on the version of vault to be installed , operating system and the system architecture.

With this enhancement the user need not have to know machine's operating system and whether it is 64 bit or 32 bit architecture, one just needs to specify the version of vault he or she is interested in and accordingly download url will be formed from download_base_url = 'https://releases.hashicorp.com/vault/' else if not from this site one can always specify the download path using download_url variable.
