### PR TITLE
Restrict json_pure gem version on older Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
+  gem "json_pure", '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
 end
 
 group :development do


### PR DESCRIPTION
Fixes the Travis CI builds, which are failing with:

```
Gem::InstallError: json_pure requires Ruby version ~> 2.0.
```
