### PR TITLE
Refactoring of module.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    staging: "https://github.com/nanliu/puppet-staging.git"
+    archive: "https://github.com/voxpupuli/puppet-archive"
   symlinks:
     vault: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ rvm:
 script: bundle exec rake test
 env:
   - PUPPET_GEM_VERSION="~> 3.8.0"
-  - PUPPET_GEM_VERSION="~> 4.0.0"
-  - PUPPET_GEM_VERSION="~> 4.4.0" DEPLOY_CANDIDATE="yes"
+  - PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
+  - PUPPET_GEM_VERSION="~> 4.4" STRICT_VARIABLES="no"
+  - PUPPET_GEM_VERSION="~> 4.6" STRICT_VARIABLES="no" DEPLOY_CANDIDATE="yes"
 matrix:
   exclude:
     - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
+      env: PUPPET_GEM_VERSION="~> 4.4"
     - rvm: 2.2
       env: PUPPET_GEM_VERSION="~> 3.8.0"
 deploy:

--- a/README.md
+++ b/README.md
@@ -21,55 +21,144 @@ This module is currently only tested on:
 include vault
 ```
 
-By default, vault requires a minimal configuration including a backend and a
-listener.
+By default, with no parameters the module will configure vault with some sensible defaults to get you running, the following parameters may be specified to configure Vault.  Please see [The official documentation](https://www.vaultproject.io/docs/config/) for further details of acceptable parameter values.
+
+## Parameters
+
+### Installation parameters
+
+These parameters control how Vault gets installed
+
+
+* `install_method`: Support the values `repo` or `archive`.  When `repo` is set the module will attempt to install a package corresponding with the value of `package_name`, when `archive` the module will attempt to download and extract a zip file from the `download_url`, the extracted file will be placed in the `bin_dir` folder
+
+#### When `install_method` is `package`
+
+* `package_name`:  Name of the package to install, default: vault
+* `package_ensure`: Desired state of the package, default: installed
+
+#### When `install_method` is `archive`
+
+* `download_url`: URL to download the vault zip distribution from.  You can specify a local file on the server with a fully qualified pathname, or use `http`, `https`, `ftp` or `s3` based URI's.
+* `download_dir`: Path to download the zip file to, default: `/tmp`
+* `manage_download_dir`: Boolean, whether or not to create the download directory, default: `false`
+* `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
+
+### Setup parameters
+
+* `user`: Customise the user vault runs as, will also create the user unless `manage_user` is false.
+
+* `manage_user`: Whether or not the module should create the user.
+
+* `group`: Customise the group vault runs as, will also create the user unless `manage_group` is false.
+
+* `manage_group`: Whether or not the module should create the group.
+
+* `bin_dir`: Directory the vault executable will be installed in.
+
+* `config_dir`: Directory the vault configuration will be kept in.
+
+* `purge_config_dir`: Whether the `config_dir` should be purged before installing the
+  generated config.
+
+* `install method`: Support the values `repo` or `archive`.  When `repo` is set the module will attempt to install a package corresponding with the value of `package_name`, when `archive
+
+* `service_name`: Customise the name of the system service
+
+* `service_provider`: Customise the name of the system service provider; this also controls the init configuration files that are installed.
+
+* `service_options`: Extra argument to pass to `vault server`, as per: `vault server --help`
+
+* `num_procs`: Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` fact.
+
+
+### Configuration parameters
+
+By default, with no parameters the module will configure vault with some sensible defaults to get you running, the following parameters may be specified to configure Vault.  Please see [The official documentation](https://www.vaultproject.io/docs/config/) for further details of acceptable parameter values.
+
+* `backend`: A hash containing the Vault backend configuration, default:
+```
+{ 'file' => { 'path' => '/var/lib/vault' }}
+```
+
+* `listener`: A hash containing the listeniner configuration, default:
+
+```
+{
+   'tcp' => {
+      'address' => '127.0.0.1:8200',
+      'tls_disable' => 1,
+    }
+}
+```
+
+* `ha_backend`: An optional hash containing the `ha_backend` configuration
+
+* `telemetry`: An optional hash containing the `telemetry` configuration
+
+* `disable_cache`: A boolean to disable or enable the cache (default: undefined)
+
+* `disable_mlock`: A boolean to disable or enable mlock [See below](#mlock) (default: undefined)
+
+* `default_lease_ttl`: A string containing the default lease TTL (default: undefined)
+
+* `max_lease_ttl`: A string containing the max lease TTL (default: undefined)
+
+* `service_options`
+  Extra argument to pass to `vault server`, as per:
+  `vault server --help`
+
+* `num_procs`
+  Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` Fact.
+
+
+## Examples
 
 ```puppet
 class { '::vault':
-    config_hash => {
-        'backend' => {
-            'file' => {
-                'path' => '/tmp',
-            }
-        },
-            'listener' => {
-                'tcp' => {
-                    'address' => '127.0.0.1:8200',
-                    'tls_disable' => 1,
-                }
-            }
+      'backend' => {
+        'file' => {
+          'path' => '/tmp',
+        }
+      },
+      listener => {
+       'tcp' => {
+         'address' => '127.0.0.1:8200',
+         'tls_disable' => 0,
+        }
+      }
     }
-}
 ```
 
 or alternatively using Hiera:
 
 ```yaml
 ---
-vault::config_hash:
-    backend:
-        file:
-            path: /tmp
-    listener:
-        tcp:
-            address: 127.0.0.1:8200
-            tls_disable: 1
+vault::backend:
+  file:
+    path: /tmp
+
+vault::listener
+  tcp:
+    address: 127.0.0.1:8200
+    tls_disable: 0
+
+vault::default_lease_ttl: 720h
+
 ```
 
-### mlock
+## mlock
 
 By default vault will use the `mlock` system call, therefore the executable will need the corresponding capability.
 
 In production, you should only consider setting the disable_mlock option on Linux systems that only use encrypted swap or do not use swap at all.
 
 The module will use `setcap` on the vault binary to enable this.
-If you do not wish to use `mlock`, modify your `config_hash` like:
+If you do not wish to use `mlock`, set the `disable_mlock` attribute to `true`
 
 ```puppet
 class { '::vault':
-    config_hash => {
-        'disable_mlock' => true
-    }
+  disable_mlock' => true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,7 @@ By default, with no parameters the module will configure vault with some sensibl
 
 * `max_lease_ttl`: A string containing the max lease TTL (default: undefined)
 
-* `service_options`
-  Extra argument to pass to `vault server`, as per:
-  `vault server --help`
-
-* `num_procs`
-  Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` Fact.
-
+* `extra_config`: A hash containing extra configuration, intended for newly released configuration not yet supported by the module. This hash will get merged with other configuration attributes into the JSON config file.
 
 ## Examples
 

--- a/lib/puppet/parser/functions/vault_sorted_json.rb
+++ b/lib/puppet/parser/functions/vault_sorted_json.rb
@@ -35,6 +35,6 @@ Would return: {'key':'value'}
     raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size != 1
     json = arguments[0].delete_if {|key, value| value == :undef }
-    return sorted_json(json)
+    return JSON.pretty_generate JSON.parse(sorted_json(json))
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,13 +3,28 @@
 # This class is called from vault for service config.
 #
 class vault::config {
+
+
+  $config_hash = delete_undef_values({
+    'backend'           => $::vault::backend,
+    'ha_backend'        => $::vault::ha_backend,
+    'listener'          => $::vault::listener,
+    'telemetry'         => $::vault::telemetry,
+    'disable_cache'     => $::vault::disable_cache,
+    'default_lease_ttl' => $::vault::default_lease_ttl,
+    'max_lease_ttl'     => $::vault::max_lease_ttl,
+    'disable_mlock'     => $::vault::disable_mlock,
+  })
+
+
   file { $::vault::config_dir:
     ensure  => directory,
     purge   => $::vault::purge_config_dir,
     recurse => $::vault::purge_config_dir,
-  } ->
+  } 
+
   file { "${::vault::config_dir}/config.json":
-    content => vault_sorted_json($::vault::config_hash),
+    content => vault_sorted_json($config_hash),
     owner   => $::vault::user,
     group   => $::vault::group,
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,53 +14,54 @@ class vault::config {
     group   => $::vault::group,
   }
 
-  case $::vault::service_provider {
-    'upstart': {
-      file { '/etc/init/vault.conf':
-        ensure  => file,
-        mode    => '0444',
-        owner   => 'root',
-        group   => 'root',
-        content => template('vault/vault.upstart.erb'),
-      }
-      file { '/etc/init.d/vault':
-        ensure => link,
-        target => '/lib/init/upstart-job',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
-      }
-    }
-    'systemd': {
-      file { '/etc/systemd/system/vault.service':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('vault/vault.systemd.erb'),
-        notify  => Exec['systemd-reload'],
-      }
-      if ! defined(Exec['systemd-reload']) {
-        exec {'systemd-reload':
-          command     => 'systemctl daemon-reload',
-          path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-          user        => 'root',
-          refreshonly => true,
+  if $::vault::install_method == 'archive' {
+    case $::vault::service_provider {
+      'upstart': {
+        file { '/etc/init/vault.conf':
+          ensure  => file,
+          mode    => '0444',
+          owner   => 'root',
+          group   => 'root',
+          content => template('vault/vault.upstart.erb'),
+        }
+        file { '/etc/init.d/vault':
+          ensure => link,
+          target => '/lib/init/upstart-job',
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
         }
       }
-    }
-    'redhat': {
-      file { '/etc/init.d/vault':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0755',
-        content => template('vault/vault.initd.erb'),
+      'systemd': {
+        file { '/etc/systemd/system/vault.service':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => template('vault/vault.systemd.erb'),
+          notify  => Exec['systemd-reload'],
+        }
+        if ! defined(Exec['systemd-reload']) {
+          exec {'systemd-reload':
+            command     => 'systemctl daemon-reload',
+            path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+            user        => 'root',
+            refreshonly => true,
+          }
+        }
+      }
+      'redhat': {
+        file { '/etc/init.d/vault':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755',
+          content => template('vault/vault.initd.erb'),
+        }
+      }
+      default: {
+        fail("vault::service_provider '${::vault::service_provider}' is not valid")
       }
     }
-    default: {
-      fail("vault::service_provider '${::vault::service_provider}' is not valid")
-    }
   }
-
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@
 class vault::config {
 
 
-  $config_hash = delete_undef_values({
+  $_config_hash = delete_undef_values({
     'backend'           => $::vault::backend,
     'ha_backend'        => $::vault::ha_backend,
     'listener'          => $::vault::listener,
@@ -15,6 +15,8 @@ class vault::config {
     'max_lease_ttl'     => $::vault::max_lease_ttl,
     'disable_mlock'     => $::vault::disable_mlock,
   })
+
+  $config_hash = merge($_config_hash, $::vault::extra_config)
 
 
   file { $::vault::config_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,8 +68,8 @@ class vault (
   $service_options  = '',
   $num_procs        = $::vault::params::num_procs,
   $install_method   = $::vault::params::install_method,
-  $package_name     = $::vault::package_name,
-  $package_ensure   = $::vault::package_ensure
+  $package_name     = $::vault::params::package_name,
+  $package_ensure   = $::vault::params::package_ensure
 ) inherits ::vault::params {
   validate_hash($config_hash)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,10 +76,12 @@ class vault (
   $download_dir        = $::vault::params::download_dir,
   $manage_download_dir = $::vault::params::manage_download_dir,
   $download_filename   = $::vault::params::download_filename,
+  $extra_config        = {},
 ) inherits ::vault::params {
 
   validate_hash($backend)
   validate_hash($listener)
+  validate_hash($extra_config)
 
   if $ha_backend {
     validate_hash($ha_backend)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,9 @@ class vault (
   $config_hash      = {},
   $service_options  = '',
   $num_procs        = $::vault::params::num_procs,
+  $install_method   = $::vault::params::install_method,
+  $package_name     = $::vault::package_name,
+  $package_ensure   = $::vault::package_ensure
 ) inherits ::vault::params {
   validate_hash($config_hash)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,10 +38,6 @@
 #   Customise the name of the system service provider; this
 #   also controls the init configuration files that are installed.
 #
-# * `config_hash`
-#   A hash representing vault's config (in JSON) as per:
-#   https://vaultproject.io/docs/config/index.html
-#
 # * `service_options`
 #   Extra argument to pass to `vault server`, as per:
 #   `vault server --help`
@@ -54,24 +50,56 @@
 #   on the system, retrieved from the ``processorcount`` Fact.
 #
 class vault (
-  $user             = $::vault::params::user,
-  $manage_user      = $::vault::params::manage_user,
-  $group            = $::vault::params::group,
-  $manage_group     = $::vault::params::manage_group,
-  $bin_dir          = $::vault::params::bin_dir,
-  $config_dir       = $::vault::params::config_dir,
-  $purge_config_dir = true,
-  $download_url     = $::vault::params::download_url,
-  $service_name     = $::vault::params::service_name,
-  $service_provider = $::vault::params::service_provider,
-  $config_hash      = {},
-  $service_options  = '',
-  $num_procs        = $::vault::params::num_procs,
-  $install_method   = $::vault::params::install_method,
-  $package_name     = $::vault::params::package_name,
-  $package_ensure   = $::vault::params::package_ensure
+  $user                = $::vault::params::user,
+  $manage_user         = $::vault::params::manage_user,
+  $group               = $::vault::params::group,
+  $manage_group        = $::vault::params::manage_group,
+  $bin_dir             = $::vault::params::bin_dir,
+  $config_dir          = $::vault::params::config_dir,
+  $purge_config_dir    = true,
+  $download_url        = $::vault::params::download_url,
+  $service_name        = $::vault::params::service_name,
+  $service_provider    = $::vault::params::service_provider,
+  $backend             = $::vault::params::backend,
+  $listener            = $::vault::params::listener,
+  $ha_backend          = $::vault::params::ha_backend,
+  $disable_cache       = $::vault::params::disable_cache,
+  $telemetry           = $::vault::params::telemetry,
+  $default_lease_ttl   = $::vault::params::default_lease_ttl,
+  $max_lease_ttl       = $::vault::params::max_lease_ttl,
+  $disable_mlock       = $::vault::params::disable_mlock,
+  $service_options     = '',
+  $num_procs           = $::vault::params::num_procs,
+  $install_method      = $::vault::params::install_method,
+  $package_name        = $::vault::params::package_name,
+  $package_ensure      = $::vault::params::package_ensure,
+  $download_dir        = $::vault::params::download_dir,
+  $manage_download_dir = $::vault::params::manage_download_dir,
+  $download_filename   = $::vault::params::download_filename,
 ) inherits ::vault::params {
-  validate_hash($config_hash)
+
+  validate_hash($backend)
+  validate_hash($listener)
+
+  if $ha_backend {
+    validate_hash($ha_backend)
+  }
+
+  if $disable_cache {
+    validate_bool($disable_cache)
+  }
+
+  if $telemetry {
+    validate_hash($telemetry)
+  }
+
+  if $default_lease_ttl {
+    validate_string($default_lease_ttl)
+  }
+
+  if $max_lease_ttl {
+    validate_string($max_lease_ttl)
+  }
 
   contain vault::install
   contain vault::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,11 +3,25 @@
 class vault::install {
   $vault_bin = "${::vault::bin_dir}/vault"
 
-  staging::deploy { 'vault.zip':
-    source  => $::vault::download_url,
-    target  => $::vault::bin_dir,
-    creates => $vault_bin,
-  } ~>
+  case $::vault::install_method {
+    'archive': {
+      staging::deploy { 'vault.zip':
+        source  => $::vault::download_url,
+        target  => $::vault::bin_dir,
+        creates => $vault_bin,
+      }
+    }
+
+    'repo': {
+      package { $::vault::package_name:
+        ensure  => $::vault::package_ensure
+      }
+    }
+
+    default: {
+      fail("Installation method ${::vault::install_method} not supported")
+    }
+  }->
   file { $vault_bin:
     owner => 'root',
     group => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@ class vault::install {
         source  => $::vault::download_url,
         target  => $::vault::bin_dir,
         creates => $vault_bin,
+        notify  => File[$vault_bin]
       }
     }
 
@@ -21,7 +22,8 @@ class vault::install {
     default: {
       fail("Installation method ${::vault::install_method} not supported")
     }
-  }->
+  }
+
   file { $vault_bin:
     owner => 'root',
     group => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,9 @@ class vault::params {
   $download_url     = 'https://releases.hashicorp.com/vault/0.6.0/vault_0.6.0_linux_amd64.zip'
   $service_name     = 'vault'
   $num_procs        = $::processorcount
+  $install_method   = 'archive'
+  $package_name     = 'vault'
+  $package_ensure   = 'installed'
 
   case $::osfamily {
     'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,18 +4,41 @@
 # It sets variables according to platform.
 #
 class vault::params {
-  $user             = 'vault'
-  $manage_user      = true
-  $group            = 'vault'
-  $manage_group     = true
-  $bin_dir          = '/usr/local/bin'
-  $config_dir       = '/etc/vault'
-  $download_url     = 'https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_linux_amd64.zip'
-  $service_name     = 'vault'
-  $num_procs        = $::processorcount
-  $install_method   = 'archive'
-  $package_name     = 'vault'
-  $package_ensure   = 'installed'
+  $user               = 'vault'
+  $manage_user        = true
+  $group              = 'vault'
+  $manage_group       = true
+  $bin_dir            = '/usr/local/bin'
+  $config_dir         = '/etc/vault'
+  $download_url       = 'https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_linux_amd64.zip'
+  $service_name       = 'vault'
+  $num_procs          = $::processorcount
+  $install_method     = 'archive'
+  $package_name       = 'vault'
+  $package_ensure     = 'installed'
+
+  $download_dir        = '/tmp'
+  $manage_download_dir = false
+  $download_filename   = 'vault.zip'
+
+  # backend and listener are mandatory, we provide some sensible
+  # defaults here
+  $backend             = { 'file' => { 'path' => '/var/lib/vault' }}
+  $listener            = {
+    'tcp' => {
+      'address' => '127.0.0.1:8200',
+      'tls_disable' => 1,
+    }
+  }
+
+  # These should always be undef as they are optional settings that
+  # should not be configured unless explicitly declared.
+  $ha_backend         = undef
+  $disable_cache      = undef
+  $telemetry          = undef
+  $default_lease_ttl  = undef
+  $max_lease_ttl      = undef
+  $disable_mlock      = undef
 
   case $::osfamily {
     'Debian': {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.3.0"
+      "version_requirement": ">= 4.2.0"
     },
     {
       "name": "puppet-archive",

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.3.0"
     },
     {
-      "name": "nanliu-staging",
-      "version_requirement": ">= 1.0.0"
+      "name": "puppet-archive",
+      "version_requirement": ">= 1.1.2"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -7,17 +7,15 @@ describe 'vault class' do
     it 'should work idempotently with no errors' do
       pp = <<-EOS
       class { '::vault':
-        config_hash => {
-          'backend' => {
-            'file' => {
-              'path' => '/tmp',
-            }
-          },
-          'listener' => {
-            'tcp' => {
-              'address' => '127.0.0.1:8200',
-              'tls_disable' => 1,
-            }
+        backend => {
+          'file' => {
+            'path' => '/tmp',
+          }
+        },
+       listener' => {
+         'tcp' => {
+           'address' => '127.0.0.1:8200',
+           'tls_disable' => 1,
           }
         }
       }

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -91,7 +91,8 @@ describe 'vault' do
 
         context "installs from download url" do
           let(:params) {{
-            :download_url => 'http://example.com/vault.zip',
+            :download_url   => 'http://example.com/vault.zip',
+            :install_method => 'archive',
           }}
 
           it {
@@ -99,6 +100,16 @@ describe 'vault' do
               .with_source('http://example.com/vault.zip')
               .that_notifies('File[/usr/local/bin/vault]')
           }
+        end
+
+        context "installs from repository" do
+          let(:params) {{
+            :install_method => 'repo',
+            :package_name   => 'vault',
+            :package_ensure => 'installed',
+          }}
+
+          it { should contain_package('vault') }
         end
       end
     end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -9,20 +9,17 @@ describe 'vault' do
         :processorcount => '3',
       }}
 
-      context "vault class with simple config_hash only" do
+      context "vault class with simple configuration" do
         let(:params) {{
-          :config_hash => {
-            'advertise_addr' => '0.0.0.0',
-            'backend' => {
-              'file' => {
-                'path' => '/data/vault'
-              }
+          :backend => {
+            'file' => {
+              'path' => '/data/vault'
+            }
             },
-            'listener' => {
-              'tcp' => {
-                'address'     => '127.0.0.1:8200',
-                'tls_disable' => 1,
-              }
+          :listener => {
+            'tcp' => {
+              'address'     => '127.0.0.1:8200',
+              'tls_disable' => 1,
             }
           }
         }}
@@ -61,7 +58,6 @@ describe 'vault' do
           is_expected.to contain_file('/etc/vault/config.json') \
             .with_owner('vault')
             .with_group('vault')
-            .with_content(/"advertise_addr":\s*"0.0.0.0"/)
             .with_content(/"backend":\s*{\s*"file":\s*{\s*"path":\s*"\/data\/vault"/)
             .with_content(/"listener":\s*{\s*"tcp":/)
             .with_content(/"address":\s*"127.0.0.1:8200"/)
@@ -77,9 +73,7 @@ describe 'vault' do
 
         context "disable mlock" do
           let(:params) {{
-            'config_hash' => {
-              'disable_mlock' => true
-            }
+              :disable_mlock => true
           }}
           it { is_expected.not_to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault') }
 
@@ -96,9 +90,9 @@ describe 'vault' do
           }}
 
           it {
-            is_expected.to contain_staging__deploy('vault.zip')
+            is_expected.to contain_archive('/tmp/vault.zip')
               .with_source('http://example.com/vault.zip')
-              .that_notifies('File[/usr/local/bin/vault]')
+              .that_comes_before('File[/usr/local/bin/vault]')
           }
         end
 
@@ -272,19 +266,16 @@ describe 'vault' do
     end
     context 'with mlock disabled' do
       let(:params) {{
-        :config_hash => {
-          'disable_mlock'  => true,
-          'advertise_addr' => '0.0.0.0',
-          'backend' => {
-            'file' => {
-              'path' => '/data/vault'
-            }
-          },
-          'listener' => {
-            'tcp' => {
-              'address'     => '127.0.0.1:8200',
-              'tls_disable' => 1,
-            }
+        :disable_mlock   => true,
+        :backend => {
+          'file' => {
+            'path' => '/data/vault'
+          }
+        },
+        :listener => {
+          'tcp' => {
+            'address'     => '127.0.0.1:8200',
+            'tls_disable' => 1,
           }
         }
       }}

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -329,7 +329,7 @@ describe 'vault' do
     let(:facts) {{
       :path                      => '/usr/local/bin:/usr/bin:/bin',
       :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => 6,
+      :operatingsystemmajrelease => '6',
       :processorcount            => '3',
     }}
     let(:params) {{

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -6,7 +6,7 @@
 # processname: vault
 # description: Init.d script for Vault Project Server
 # pidfile: /var/run/vault.pid
-# config: <%= scope.lookupvar('vault::config_dir') %>/config.json
+# config: <%= scope['vault::config_dir'] %>/config.json
 ###########################################################################################################
 # this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
 # any changes will be overwritten if Puppet is run again
@@ -30,18 +30,18 @@
 # Check that networking is up.
 [ "$NETWORKING" = "no" ] && exit 0
 
-exec="<%= scope.lookupvar('vault::bin_dir') %>/vault"
+exec="<%= scope['vault::bin_dir'] %>/vault"
 prog=${exec##*/}
 
 lockfile="/var/lock/subsys/$prog"
 pidfile="/var/run/${prog}.pid"
 logfile="/var/log/${prog}.log"
 sysconfig="/etc/sysconfig/$prog"
-conffile="<%= scope.lookupvar('vault::config_dir') %>/config.json"
+conffile="<%= scope['vault::config_dir'] %>/config.json"
 
 [ -f $sysconfig ] && . $sysconfig
 
-OPTIONS=$OPTIONS:-"<%= scope.lookupvar('vault::service_options') %>"
+OPTIONS=$OPTIONS:-"<%= scope['vault::service_options'] %>"
 
 start() {
     [ -x $exec ] || exit 5
@@ -49,9 +49,9 @@ start() {
 
     echo -n $"Starting $prog: "
     touch $logfile $pidfile
-    chown <%= scope.lookupvar('vault::user') %> $logfile $pidfile
-    export GOMAXPROCS=${GOMAXPROCS:-<%= scope.lookupvar('vault::num_procs') %>}
-    daemon --user <%= scope.lookupvar('vault::user') %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
+    chown <%= scope['vault::user'] %> $logfile $pidfile
+    export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
+    daemon --user <%= scope['vault::user'] %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -11,13 +11,14 @@ Requires=basic.target network.target
 After=basic.target network.target
 
 [Service]
-User=<%= scope.lookupvar('vault::user') %>
-Group=<%= scope.lookupvar('vault::group') %>
+User=<%= scope['vault::user'] %>
+Group=<%= scope['vault::group'] %>
 PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=read-only
-<% if scope.lookupvar('vault::config_hash')['disable_mlock'] -%>
+<% # Still require check for :undef for Puppet 3.x -%>
+<% if scope['vault::disable_mlock'] && scope['vault::disable_mlock'] != :undef -%>
 CapabilityBoundingSet=CAP_SYSLOG
 NoNewPrivileges=yes
 <% else -%>
@@ -26,8 +27,8 @@ Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
 <% end -%>
-Environment=GOMAXPROCS=<%= scope.lookupvar('vault::num_procs') %>
-ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
+Environment=GOMAXPROCS=<%= scope['vault::num_procs'] %>
+ExecStart=<%= scope['vault::bin_dir'] %>/vault server -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
 KillSignal=SIGINT
 TimeoutStopSec=30s
 Restart=on-failure

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -7,18 +7,18 @@ description "vault server"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]
 
-env VAULT=<%= scope.lookupvar('vault::bin_dir') %>/vault
-env CONFIG=<%= scope.lookupvar('vault::config_dir') %>/config.json
-env USER=<%= scope.lookupvar('vault::user') %>
-env GROUP=<%= scope.lookupvar('vault::group') %>
+env VAULT=<%= scope['vault::bin_dir'] %>/vault
+env CONFIG=<%= scope['vault::config_dir'] %>/config.json
+env USER=<%= scope['vault::user'] %>
+env GROUP=<%= scope['vault::group'] %>
 env PID_FILE=/var/run/vault.pid
 env LOG_FILE=/var/log/vault.log
 
 script
-    export GOMAXPROCS=${GOMAXPROCS:-<%= scope.lookupvar('vault::num_procs') %>}
+    export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
     exec >> $LOG_FILE 2>&1
-    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope.lookupvar('vault::service_options') %>
+    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope['vault::service_options'] %>
 end script
 
 respawn


### PR DESCRIPTION
## Summary

I've done a fair bit of refactoring to this module that I'd like to merge upstream in the hope of a next major release.  It's quite a large change so I've detailed as much as I can below.....
## Changes
### Replacement of `config_hash` (API change)

This PR removes the generic `config_hash` attribute and replaces it with more fine grained controls by adding the following attributes to the `vault` class
- `backend` (Hash)
- `listener` (Hash)
- `ha_backend` (Hash, optional)
- `telemetry` (Hash, optional)
- `disable_mlock` (Boolean, optional)
- `disable_cache` (Boolean, optional)
- `default_lease_ttl` (String, optional)
- `max_lease_ttl` (String, optional)
- `disable_mlock` (Boolean, optional)

This has many benefits, especially when used with Hiera...  For example to disable mlock in my dev environment I would have to re-create the entire hash at the level in the hierarchy, with this change you can just set `vault::disable_mlock: true` at the appropriate place.   This also improves validation, and makes the module more understandable.

This is an API breaking change.  If you would prefer to maintain a backwardly compatible version of the module and deprecate the `config_hash` variable over the course of several releases, this would be fairly easy to implement.   I could put `config_hash` back in with a default of `undef` and put a conditional around the building of `vault::config::config_hash` to use this value if it's supplied instead of the new attributes, and document the attribute as deprecated.    I have not done this as I don't feel a 0.x module needs to worry too much about deprecating things over multiple releases - but I'm happy to add it if requested.
### Allow for package installations (#36)

As this was quite a major refactor I decided to pull in the PR from @miso321 adding package installations into this PR since there have been no objections to it, and it's currently unmerged.

Closes #36 
### Replaced `nanliu/staging` for `puppet/archive`

This is a modernisation, `nanliu/staging` is currently not under active feature development, the advised replacement for it is `puppet/archive`.
### JSON file now has line breaks.

The `vault_sorted_json` function now gives a prettier output with line breaks and indenting by using `JSON.pretty_generate`
### Other changes
- Changed the `scope.lookupvar()` notation in templates to `scope[]`, this is more best practice
- Updated spec tests (rspec passes for me)
- `puppetlabs/stdlib` dependancy set to 4.3 (for the `delete_undef_values` function
- Added documentation to the README for all class parameters
