### PR TITLE
Added manage_backend_dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These parameters control how Vault gets installed
 
 * `num_procs`: Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` fact.
 
+* `manage_backend_dir`: When using the file backend, this boolean determines whether or not the path (as specified in the `['file']['path']` section of the backend config) is created, and the owner and group set to the vault user.  Default: false
 
 ### Configuration parameters
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,6 @@ class vault::config {
 
   $config_hash = merge($_config_hash, $::vault::extra_config)
 
-
   file { $::vault::config_dir:
     ensure  => directory,
     purge   => $::vault::purge_config_dir,
@@ -30,6 +29,23 @@ class vault::config {
     owner   => $::vault::user,
     group   => $::vault::group,
   }
+
+  # If using the file backend then the path must exist and be readable
+  # and writable by the vault user, if we have a file path and the
+  # manage_backend_dir attribute is true, then we create it here.
+  #
+  if $::vault::backend['file'] and $::vault::manage_backend_dir {
+    if ! $::vault::backend['file']['path'] {
+      fail('Must provide a path attribute to backend file')
+    }
+
+    file { $::vault::backend['file']['path']:
+      ensure => directory,
+      owner  => $::vault::user,
+      group  => $::vault::group,
+    }
+  }
+
 
   if $::vault::install_method == 'archive' {
     case $::vault::service_provider {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class vault (
   $service_name        = $::vault::params::service_name,
   $service_provider    = $::vault::params::service_provider,
   $backend             = $::vault::params::backend,
+  $manage_backend_dir  = $::vault::params::manage_backend_dir,
   $listener            = $::vault::params::listener,
   $ha_backend          = $::vault::params::ha_backend,
   $disable_cache       = $::vault::params::disable_cache,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class vault::params {
   # backend and listener are mandatory, we provide some sensible
   # defaults here
   $backend             = { 'file' => { 'path' => '/var/lib/vault' }}
+  $manage_backend_dir  = false
   $listener            = {
     'tcp' => {
       'address' => '127.0.0.1:8200',

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -38,6 +38,7 @@ describe 'vault' do
         }
         it { is_expected.to contain_user('vault') }
         it { is_expected.to contain_group('vault') }
+        it { is_expected.not_to contain_file('/data/vault') }
 
         context "do not manage user and group" do
           let(:params) {{
@@ -105,6 +106,24 @@ describe 'vault' do
 
           it { should contain_package('vault') }
         end
+      end
+
+      context "when specifying manage_backend_dir" do
+        let(:params) {{
+          :manage_backend_dir => true,
+          :backend => {
+            'file' => {
+              'path' => '/data/vault'
+            }
+            }
+        }}
+
+        it {
+          is_expected.to contain_file('/data/vault')
+            .with_ensure('directory')
+            .with_owner('vault')
+            .with_group('vault')
+        }
       end
     end
   end


### PR DESCRIPTION
When using the `file` backend, `vault init` will fail if the path does not exist and owned by the vault user.  There is currently no way to do this using the module so has to be done by hand, and seems like something that you would want to do at configuration time.

This PR adds a `manage_backend_dir` option to do just that, if you are using the file backend.

It defaults to `false` so it doesn't break existing functionality.
