### PR TITLE
removed quotes from puppet attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ If you do not wish to use `mlock`, set the `disable_mlock` attribute to `true`
 
 ```puppet
 class { '::vault':
-  'disable_mlock' => true
+  disable_mlock => true
 }
 ```
 


### PR DESCRIPTION
https://github.com/jsok/puppet-vault/commit/4a9cc974951e9ab5b10cb65f198767fde7847029 tried to fix a typo in the README, but it added quotes instead of removing them - it's a puppet attribute :-)
