### PR TITLE
base cap_ipc_lock on file instead of file notify

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,9 +40,9 @@ class vault::install {
 
   if !$::vault::disable_mlock {
     exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
-      path        => ['/sbin', '/usr/sbin'],
-      subscribe   => File[$vault_bin],
-      refreshonly => true,
+      path      => ['/sbin', '/usr/sbin', '/usr/bin', ],
+      subscribe => File[$vault_bin]
+      unless    => 'getcap /usr/local/bin/vault | grep cap_ipc_lock+ep',
     }
   }
 


### PR DESCRIPTION
##### SUMMARY

To be allowed to use the mlock option when running vault with the
permission of a user other than root, such as 'vault', the
binary (/usr/local/bin/)vault needs to have the cap_ipc_lock capability
set.

Currently, the capabilities are refreshed only when the binary
changes. Failures to set the capability are reported once and ignored
afterwards.

Making the exec-resource which sets the capability depend on a
test-condition instead of a change of the binary makes puppet check the
capabilities on the file on each run and changes the capability if
cap_ipc_lock is missing on the file.

(Tested using the test-kitchen framework on privileged lxd containers running CentOS7)

	modified:   manifests/install.pp