### PR TITLE
base cap_ipc_lock on file instead of file notify

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,9 +40,9 @@ class vault::install {
 
   if !$::vault::disable_mlock {
     exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
-      path        => ['/sbin', '/usr/sbin'],
-      subscribe   => File[$vault_bin],
-      refreshonly => true,
+      path      => ['/sbin', '/usr/sbin', '/usr/bin', ],
+      subscribe => File[$vault_bin],
+      unless    => 'getcap /usr/local/bin/vault | grep cap_ipc_lock+ep',
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,7 +42,7 @@ class vault::install {
     exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
       path      => ['/sbin', '/usr/sbin', '/usr/bin', ],
       subscribe => File[$vault_bin],
-      unless    => 'getcap /usr/local/bin/vault | grep cap_ipc_lock+ep',
+      unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
     }
   }
 

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -68,7 +68,7 @@ describe 'vault' do
         it { is_expected.to contain_file('/usr/local/bin/vault').with_mode('0555') }
         it {
           is_expected.to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault')
-            .with_refreshonly('true')
+            .with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep')
             .that_subscribes_to('File[/usr/local/bin/vault]')
         }
 
@@ -373,7 +373,7 @@ describe 'vault' do
       }
       it {
         is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
-          .with_refreshonly('true')
+          .with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep')
           .that_subscribes_to('File[/opt/bin/vault]')
       }
       it { is_expected.to contain_file('/opt/etc/vault/config.json') }

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -373,7 +373,7 @@ describe 'vault' do
       }
       it {
         is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
-          .with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep')
+          .with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
           .that_subscribes_to('File[/opt/bin/vault]')
       }
       it { is_expected.to contain_file('/opt/etc/vault/config.json') }


### PR DESCRIPTION
To be allowed to use the mlock option when running vault with the
permission of a user other than root, such as 'vault', the
binary (/usr/local/bin/)vault needs to have the cap_ipc_lock capability
set.

Currently, the capabilities are refreshed only when the binary
changes. Failures to set the capability are reported once and ignored
afterwards.

Making the exec-resource which sets the capability depend on a
test-condition instead of a change of the binary makes puppet check the
capabilites on the file on each run and changes the capability if
cap_ipc_lock is missing on the file.

(tested on test-kitchen using privileged lxd containers running CentOS7. Please excuse my fat fingers and the noise.)

	modified:   manifests/install.pp