### PR TITLE
[khdevel_grep-path]

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,7 +40,7 @@ class vault::install {
 
   if !$::vault::disable_mlock {
     exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
-      path      => ['/sbin', '/usr/sbin', '/usr/bin', ],
+      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
       subscribe => File[$vault_bin],
       unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### TESTS/SPECS

<!---
Pull Requests require passing Travis CI tests.
If you have added new functionality, you **must** include spec tests,
see https://github.com/jsok/puppet-vault/tree/master/spec/classes

If you are adding support for a new OS, then you should also create
acceptance tests, see https://github.com/jsok/puppet-vault/tree/master/spec/acceptance
-->

<!--- Describe how you have tested this change -->

- added '/bin' as a PATH for 'grep' command.
It makes that on Ubuntu14 the 'unless => "getcap ${vault_bin} | grep cap_ipc_lock+ep",'
command works without puppet's ERROR

Changes to be committed:
- changed: manifests/install.pp