### PR TITLE
Upgrade to 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2017-01-10 v1.1.5-dev
+- Update to vault 0.6.4
+
 ## 2016-12-07 v1.1.4
 - Update to vault 0.6.3
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Puppet module to install and run [Hashicorp Vault](https://vaultproject.io).
 
-Installs `v0.6.3` Linux AMD64 binary from the Hashicorp releases CDN by default.
+Installs `v0.6.4` Linux AMD64 binary from the Hashicorp releases CDN by default.
 
 ## Support
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class vault::params {
   $manage_group       = true
   $bin_dir            = '/usr/local/bin'
   $config_dir         = '/etc/vault'
-  $download_url       = 'https://releases.hashicorp.com/vault/0.6.3/vault_0.6.3_linux_amd64.zip'
+  $download_url       = 'https://releases.hashicorp.com/vault/0.6.4/vault_0.6.4_linux_amd64.zip'
   $service_name       = 'vault'
   $num_procs          = $::processorcount
   $install_method     = 'archive'


### PR DESCRIPTION
##### SUMMARY

Bump default vault install to 0.6.4

##### TESTS/SPECS

Existing specs cover this change.