### PR TITLE
Fix matrix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,17 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 sudo: false
-rvm:
-  - 1.9.3
-  - 2.1.9
-  - 2.3.1
 script: bundle exec rake test
-env:
-  - PUPPET_GEM_VERSION="~> 3.8.0"
-  - PUPPET_GEM_VERSION="~> 4.6"
-  - PUPPET_GEM_VERSION="~> 4.8" DEPLOY_CANDIDATE="yes"
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.6"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.8"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.8.0" LEGACY=yes
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.9" DEPLOY_CANDIDATE=yes
+  - rvm: 2.4.0
+    env: PUPPET_GEM_VERSION="~> 4" FUTURE=yes
+  allow_failures:
+  - rvm: 1.9.3
 deploy:
   provider: puppetforge
   user: jsok
@@ -29,5 +21,4 @@ deploy:
     secure: Fpvb/pZBy+FBpcXkQua6eEWN/4/klJjgFvBzDocrEa8ud5MGs8YuERKENoZ16bFzCtnyytRGZbiXJtqo4+IkxY0EFuCWgw1BH0ekljXWsuTi0ZCrYgedjy0Tykj6cgPkLecBzqtPe5b1gXwmIamlYQkVdnyglZEkSKvo9GqYX/VYSs7cc5mJ5bP5zgAr7U1jBQCKxD95kSt28NwIliekX1KoUqEVhxsHW5fzQa+4eS8vz7HUBppkJoUpHJfjXuoZKWXR4lQka4VgIZXflHno6OH908B0JiFoZI6klOInrn6eZbpF10CmjbK7ZCMIKdiPiVqzDQJgsSqg2n+9fA6TGbEj5A3K8VZtqp7MGd3b5HBfeVNPTPEAFGi4SkWPGwb2l53fUxP7T/NQUQ130GGNKdJdFmVW6Y6i2q9zrWWYZB1zbHRac/lY3uDd6qRxmbDYJzzTqMUPpl5eyBtRbg0XWuxTR1R9yhSwNw+N1sz1CaqT27MvgHqNRrISPSAXRfA+KP5mV8n+gInZVKiXf1BkNtPZJ+t2WO7jhKkC05WRGy0HAi2jaZiSL39bBMQOuoTCGlgo3h146PE27dJ2E4Yd3OBPn3vV/FrU8zuRFt77kOlffCq7yL7zv4OORfIgUql2RvEJ0aLA3jIxrKve8uQZFQ6Y7NjuFMQnKpG+lntW5xw=
   on:
     tags: true
-    rvm: 2.3.1
     condition: "$DEPLOY_CANDIDATE = yes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2017-02-09 v1.1.8-dev
+- Test with Puppet 4.9 by default
+- Test with bleedging edge Puppet 4
+- Allow legacy Puppet 3 builds to fail in CI
+
 ## 2017-02-09 v1.1.7
 - Update to vault 0.6.5
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake", '~> 11'
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.6.0'
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.9'
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
##### SUMMARY

Re-work Travis CI matrix build combinations. Test for:

 * Legacy Ruby and unsupported Puppet 3 version
 * Latest supported Puppet 4
 * Future Ruby version and latest Puppet 4

##### TESTS/SPECS

Existing specs.