### PR TITLE
Ensure unzip is installed when installing through archive

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,6 +19,13 @@ class vault::install {
           creates      => $vault_bin,
           before       => File[$vault_bin],
         }
+
+        if !defined(Package['unzip']) {
+          package { 'unzip':
+            ensure => installed,
+            before => Archive["${::vault::download_dir}/${::vault::download_filename}"],
+          }
+        }
       }
 
     'repo': {


### PR DESCRIPTION
Ensure unzip is installed when installing vault through the archive method.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>