### PR TITLE
Use dedicated initsystem module instead of ad-hoc OS detection

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,19 +43,8 @@ class vault::params {
 
   $manage_service = true
 
-  case $::osfamily {
-    'Debian': {
-      $service_provider = 'upstart'
-    }
-    'RedHat': {
-      if ($::operatingsystemmajrelease == '6' or $::operatingsystem == 'Amazon') {
-        $service_provider = 'redhat'
-      } else {
-        $service_provider = 'systemd'
-      }
-    }
-    default: {
+  $service_provider = $::initsystem
+  if $service_provider.empty {
       fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
-    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,10 @@
     {
       "name": "puppet-archive",
       "version_requirement": ">= 1.1.2 < 2.0.0"
+    },
+    {
+      "name": "hfm-initsystem",
+      "version_requirement": ">= 0.2.0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -45,7 +45,7 @@ describe 'vault class' do
       it { is_expected.to be_grouped_into 'root' }
     end
 
-    if (fact('osfamily') == 'Debian')
+    if (fact('initsystem') == 'upstart')
       describe file('/etc/init/vault.conf') do
         it { is_expected.to be_file }
         it { is_expected.to be_mode 444 }
@@ -62,32 +62,30 @@ describe 'vault class' do
         it { is_expected.to be_symlink }
         it { is_expected.to be_linked_to '/lib/init/upstart-job' }
       end
-    elsif (fact('osfamily') == 'RedHat')
-      if (fact('operatingsystemmajrelease') == '6')
-        describe file('/etc/init.d/vault') do
-          it { is_expected.to be_file }
-          it { is_expected.to be_mode 755 }
-          it { is_expected.to be_owned_by 'root' }
-          it { is_expected.to be_grouped_into 'root' }
-          its(:content) { is_expected.to include 'daemon --user vault "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"' }
-          its(:content) { is_expected.to include 'conffile="/etc/vault/config.json"' }
-          its(:content) { is_expected.to include 'exec="/usr/local/bin/vault"' }
-          its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
-        end
-      else
-        describe file('/etc/systemd/system/vault.service') do
-          it { is_expected.to be_file }
-          it { is_expected.to be_mode 644 }
-          it { is_expected.to be_owned_by 'root' }
-          it { is_expected.to be_grouped_into 'root' }
-          its(:content) { is_expected.to include 'User=vault' }
-          its(:content) { is_expected.to include 'Group=vault' }
-          its(:content) { is_expected.to include 'ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json ' }
-          its(:content) { is_expected.to match /Environment=GOMAXPROCS=\d+/ }
-        end
-        describe command('systemctl list-units') do
-          its(:stdout) { is_expected.to include 'vault.service' }
-        end
+    elsif (fact('initsystem') == 'redhat')
+      describe file('/etc/init.d/vault') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_mode 755 }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+        its(:content) { is_expected.to include 'daemon --user vault "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"' }
+        its(:content) { is_expected.to include 'conffile="/etc/vault/config.json"' }
+        its(:content) { is_expected.to include 'exec="/usr/local/bin/vault"' }
+        its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
+      end
+    elsif (fact('initsystem') == 'systemd')
+      describe file('/etc/systemd/system/vault.service') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_mode 644 }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+        its(:content) { is_expected.to include 'User=vault' }
+        its(:content) { is_expected.to include 'Group=vault' }
+        its(:content) { is_expected.to include 'ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json ' }
+        its(:content) { is_expected.to match /Environment=GOMAXPROCS=\d+/ }
+      end
+      describe command('systemctl list-units') do
+        its(:stdout) { is_expected.to include 'vault.service' }
       end
     end
 

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -7,6 +7,7 @@ describe 'vault' do
         :path           => '/usr/local/bin:/usr/bin:/bin',
         :osfamily       => "#{osfamily}",
         :processorcount => '3',
+        :initsystem     => 'systemd',
       }}
 
       context "vault class with simple configuration" do
@@ -150,6 +151,7 @@ describe 'vault' do
       :operatingsystem           => 'Amazon',
       :operatingsystemmajrelease => '7',
       :processorcount            => '3',
+      :initsystem                => 'redhat',
    }}
    context 'includes SysV init script' do
       it {
@@ -203,6 +205,7 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '6',
       :processorcount            => '3',
+      :initsystem                => 'redhat',
     }}
     context 'includes SysV init script' do
       it {
@@ -256,6 +259,7 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '7',
       :processorcount            => '3',
+      :initsystem                => 'systemd',
     }}
     context 'includes systemd init script' do
       it {
@@ -346,6 +350,7 @@ describe 'vault' do
       :path           => '/usr/local/bin:/usr/bin:/bin',
       :osfamily       => 'Debian',
       :processorcount => '3',
+      :initsystem     => 'upstart',
     }}
     context 'includes init link to upstart-job' do
       it {
@@ -411,6 +416,7 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '6',
       :processorcount            => '3',
+      :initsystem                => 'redhat',
     }}
     let(:params) {{
       :service_provider => 'foo',
@@ -427,6 +433,7 @@ describe 'vault' do
       :path           => '/usr/local/bin:/usr/bin:/bin',
       :osfamily       => 'nexenta',
       :processorcount => '3',
+      :initsystem     => nil,
     }}
     it {
       expect { should contain_class('vault') }.to raise_error(Puppet::Error, /Module vault is not supported on osfamily 'nexenta'/)


### PR DESCRIPTION
##### SUMMARY

Not that I think this `hfm-initsystem` module is so great (it has its shortcomings, i.e. it’s still comparing OS versions instead of actually checking what’s running as PID 1), but it does a better job.

##### TESTS/SPECS

I did not bother much with the tests, it’s too much work for my purposes. (I just need it to work on a particular version of Ubuntu which doesn’t use upstart. My changes fulfil that goal.)

Apologies for being lazy. I am leaving the box below ticked, to allow edits from maintainers, so you are welcome to update the tests some more, and maybe update `metadata.json` to include all the newly supported OS.