### PR TITLE
Add a configurable version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ When `repo` is set the module will attempt to install a package corresponding wi
 
 When `archive` the module will attempt to download and extract a zip file from the `download_url`, the extracted file will be placed in the `bin_dir` folder.
 
-* `download_url`: URL to download the vault zip distribution from.  You can specify a local file on the server with a fully qualified pathname, or use `http`, `https`, `ftp` or `s3` based URI's.
+* `download_url`: Manual URL to download the vault zip distribution from.  You can specify a local file on the server with a fully qualified pathname, or use `http`, `https`, `ftp` or `s3` based URI's. default: `undef`
+* `download_url_base`: This is the base URL for the hashicorp releases. If no manual `download_url` is specified, the module will download from hashicorp. default: `https://releases.hashicorp.com/vault/`
 * `download_dir`: Path to download the zip file to, default: `/tmp`
 * `manage_download_dir`: Boolean, whether or not to create the download directory, default: `false`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
+* `version`: The Version of vault to download. default: `0.6.5`
 
 ### Configuration parameters
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ When `archive` the module will attempt to download and extract a zip file from t
 
 * `download_url`: Manual URL to download the vault zip distribution from.  You can specify a local file on the server with a fully qualified pathname, or use `http`, `https`, `ftp` or `s3` based URI's. default: `undef`
 * `download_url_base`: This is the base URL for the hashicorp releases. If no manual `download_url` is specified, the module will download from hashicorp. default: `https://releases.hashicorp.com/vault/`
+* `download_extension`: The extension of the vault download when using hashicorp releases. default: `zip`
 * `download_dir`: Path to download the zip file to, default: `/tmp`
 * `manage_download_dir`: Boolean, whether or not to create the download directory, default: `false`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,9 @@
 # * `download_url_base`
 #   Hashicorp base URL to download vault zip distribution from.
 #
+# * `download_extension`
+#   The extension of the vault download
+#
 # * `service_name`
 #   Customise the name of the system service
 #
@@ -68,9 +71,10 @@ class vault (
   $purge_config_dir    = true,
   $download_url        = $::vault::params::download_url,
   $download_url_base   = $::vault::params::download_url_base,
+  $download_extension  = $::vault::params::download_extension,
   $service_name        = $::vault::params::service_name,
   $service_provider    = $::vault::params::service_provider,
-  $manage_service     = $::vault::params::manage_service,
+  $manage_service      = $::vault::params::manage_service,
   $backend             = $::vault::params::backend,
   $manage_backend_dir  = $::vault::params::manage_backend_dir,
   $listener            = $::vault::params::listener,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,10 @@
 #   generated config.
 #
 # * `download_url`
-#   URL to download the vault zip distribution from.
+#   Manual URL to download the vault zip distribution from.
+#
+# * `download_url_base`
+#   Hashicorp base URL to download vault zip distribution from.
 #
 # * `service_name`
 #   Customise the name of the system service
@@ -52,6 +55,9 @@
 #   because Vault can block a scheduler thread". Default: number of CPUs
 #   on the system, retrieved from the ``processorcount`` Fact.
 #
+# * `version`
+#   The version of Vault to install
+#
 class vault (
   $user                = $::vault::params::user,
   $manage_user         = $::vault::params::manage_user,
@@ -61,6 +67,7 @@ class vault (
   $config_dir          = $::vault::params::config_dir,
   $purge_config_dir    = true,
   $download_url        = $::vault::params::download_url,
+  $download_url_base   = $::vault::params::download_url_base,
   $service_name        = $::vault::params::service_name,
   $service_provider    = $::vault::params::service_provider,
   $manage_service     = $::vault::params::manage_service,
@@ -81,6 +88,9 @@ class vault (
   $download_dir        = $::vault::params::download_dir,
   $manage_download_dir = $::vault::params::manage_download_dir,
   $download_filename   = $::vault::params::download_filename,
+  $version             = $::vault::params::version,
+  $os                  = $::vault::params::os,
+  $arch                = $::vault::params::arch,
   $extra_config        = {},
 ) inherits ::vault::params {
 
@@ -107,6 +117,10 @@ class vault (
   if $max_lease_ttl {
     validate_string($max_lease_ttl)
   }
+
+  # lint:ignore:140chars
+  $real_download_url    = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
+  # lint:endignore
 
   contain vault::install
   contain vault::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class vault::install {
           ensure       => present,
           extract      => true,
           extract_path => $::vault::bin_dir,
-          source       => $::vault::download_url,
+          source       => $::vault::real_download_url,
           cleanup      => true,
           creates      => $vault_bin,
           before       => File[$vault_bin],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,9 @@ class vault::params {
   $manage_group       = true
   $bin_dir            = '/usr/local/bin'
   $config_dir         = '/etc/vault'
-  $download_url       = 'https://releases.hashicorp.com/vault/0.6.5/vault_0.6.5_linux_amd64.zip'
+  $download_url       = undef
+  $download_url_base  = 'https://releases.hashicorp.com/vault/'
+  $version            = '0.6.5'
   $service_name       = 'vault'
   $num_procs          = $::processorcount
   $install_method     = 'archive'
@@ -58,4 +60,13 @@ class vault::params {
       fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
     }
   }
+	case $::architecture {
+    'x86_64', 'amd64': { $arch = 'amd64' }
+    'i386':            { $arch = '386'   }
+    /^arm.*/:          { $arch = 'arm'   }
+    default:           {
+      fail("Unsupported kernel architecture: ${::architecture}")
+    }
+  }
+	$os = downcase($::kernel)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class vault::params {
   $config_dir         = '/etc/vault'
   $download_url       = undef
   $download_url_base  = 'https://releases.hashicorp.com/vault/'
+  $download_extension = 'zip'
   $version            = '0.6.5'
   $service_name       = 'vault'
   $num_procs          = $::processorcount

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,7 +60,7 @@ class vault::params {
       fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
     }
   }
-	case $::architecture {
+  case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }
     'i386':            { $arch = '386'   }
     /^arm.*/:          { $arch = 'arm'   }
@@ -68,5 +68,5 @@ class vault::params {
       fail("Unsupported kernel architecture: ${::architecture}")
     }
   }
-	$os = downcase($::kernel)
+  $os = downcase($::kernel)
 }

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -7,6 +7,8 @@ describe 'vault' do
         :path           => '/usr/local/bin:/usr/bin:/bin',
         :osfamily       => "#{osfamily}",
         :processorcount => '3',
+        :architecture   => 'x86_64',
+        :kernel         => 'Linux',
       }}
 
       context "vault class with simple configuration" do
@@ -150,6 +152,8 @@ describe 'vault' do
       :operatingsystem           => 'Amazon',
       :operatingsystemmajrelease => '7',
       :processorcount            => '3',
+      :architecture              => 'x86_64',
+      :kernel                    => 'Linux',
    }}
    context 'includes SysV init script' do
       it {
@@ -203,6 +207,8 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '6',
       :processorcount            => '3',
+      :architecture              => 'x86_64',
+      :kernel                    => 'Linux',
     }}
     context 'includes SysV init script' do
       it {
@@ -256,6 +262,8 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '7',
       :processorcount            => '3',
+      :architecture              => 'x86_64',
+      :kernel                    => 'Linux',
     }}
     context 'includes systemd init script' do
       it {
@@ -346,6 +354,8 @@ describe 'vault' do
       :path           => '/usr/local/bin:/usr/bin:/bin',
       :osfamily       => 'Debian',
       :processorcount => '3',
+      :architecture              => 'x86_64',
+      :kernel                    => 'Linux',
     }}
     context 'includes init link to upstart-job' do
       it {
@@ -411,6 +421,8 @@ describe 'vault' do
       :osfamily                  => 'RedHat',
       :operatingsystemmajrelease => '6',
       :processorcount            => '3',
+      :architecture              => 'x86_64',
+      :kernel                    => 'Linux',
     }}
     let(:params) {{
       :service_provider => 'foo',

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -86,6 +86,29 @@ describe 'vault' do
           }
         end
 
+        context "default download options" do
+          it {
+            is_expected.to contain_archive('/tmp/vault.zip')
+              .with_source('https://releases.hashicorp.com/vault/0.6.5/vault_0.6.5_linux_amd64.zip')
+              .that_comes_before('File[/usr/local/bin/vault]')
+          }
+        end
+
+        context "specifying a custom download params" do
+          let(:params) {{
+            :version  => '0.6.0',
+            :download_url_base => 'http://my_site.example.com/vault/',
+            :package_name => 'vaultbinary',
+            :download_extension => 'tar.gz'
+          }}
+
+          it {
+            is_expected.to contain_archive('/tmp/vault.zip')
+              .with_source('http://my_site.example.com/vault/0.6.0/vaultbinary_0.6.0_linux_amd64.tar.gz')
+              .that_comes_before('File[/usr/local/bin/vault]')
+          }
+        end
+
         context "installs from download url" do
           let(:params) {{
             :download_url   => 'http://example.com/vault.zip',


### PR DESCRIPTION
##### SUMMARY
Instead of hardcoding the URL, you can now simply update the version
string. This also means specifying your own URL is relatively
simple/straightforward


##### TESTS/SPECS

Tests are passing, have added facter facts to some of the tests 
