### PR TITLE
set owner and group for config dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,8 @@ class vault::config {
     ensure  => directory,
     purge   => $::vault::purge_config_dir,
     recurse => $::vault::purge_config_dir,
+    owner   => $::vault::user,
+    group   => $::vault::group,
   }
 
   file { "${::vault::config_dir}/config.json":


### PR DESCRIPTION
##### SUMMARY
if you have a umask 027 the config dir is not readable by vault user