### PR TITLE
Update to vault 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2017-05-08 1.2.2-dev
+- Update to vault 0.7.1
+
 ## 2017-04-22 1.2.1
 - Update to rspec 3.5
 - Ruby 2.4 Fixnum deprecation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Puppet module to install and run [Hashicorp Vault](https://vaultproject.io).
 
-Installs `v0.7.0` Linux AMD64 binary from the Hashicorp releases CDN by default.
+Installs `v0.7.1` Linux AMD64 binary from the Hashicorp releases CDN by default.
 
 ## Support
 
@@ -76,7 +76,7 @@ The module will **not** manage any required packages to un-archive, e.g. `unzip`
 * `download_dir`: Path to download the zip file to, default: `/tmp`
 * `manage_download_dir`: Boolean, whether or not to create the download directory, default: `false`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
-* `version`: The Version of vault to download. default: `0.7.0`
+* `version`: The Version of vault to download. default: `0.7.1`
 
 ### Configuration parameters
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class vault::params {
   $download_url       = undef
   $download_url_base  = 'https://releases.hashicorp.com/vault/'
   $download_extension = 'zip'
-  $version            = '0.7.0'
+  $version            = '0.7.1'
   $service_name       = 'vault'
   $num_procs          = $::processorcount
   $install_method     = 'archive'


### PR DESCRIPTION
##### SUMMARY
Bump default version to vault-0.7.1

##### TESTS/SPECS

Covered by existing specs.