### PR TITLE
Allow client only install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `manage_backend_dir`: When using the file backend, this boolean determines whether or not the path (as specified in the `['file']['path']` section of the backend config) is created, and the owner and group set to the vault user.  Default: `false`
 
+* `mode`: Defaults to server, set to Client to only install binary.
 ### Installation parameters
 
 #### When `install_method` is `repo`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@
 # * `service_options`
 #   Extra argument to pass to `vault server`, as per:
 #   `vault server --help`
-
+#
 # * `manage_service`
 #   Instruct puppet to manage service or not
 #
@@ -61,6 +61,8 @@
 # * `version`
 #   The version of Vault to install
 #
+# * `mode`
+#   Allows installing the client only by specifying client. Defalts to server.
 class vault (
   $user                = $::vault::params::user,
   $manage_user         = $::vault::params::manage_user,
@@ -95,6 +97,7 @@ class vault (
   $version             = $::vault::params::version,
   $os                  = $::vault::params::os,
   $arch                = $::vault::params::arch,
+  $mode                = $::vault::params::mode,
   $extra_config        = {},
 ) inherits ::vault::params {
 
@@ -127,10 +130,12 @@ class vault (
   # lint:endignore
 
   contain vault::install
-  contain vault::config
-  contain vault::service
 
-  Class['vault::install'] -> Class['vault::config']
-  Class['vault::config'] ~> Class['vault::service']
+  if $mode == 'server' {
+    contain vault::config
+    contain vault::service
 
+    Class['vault::install'] -> Class['vault::config']
+    Class['vault::config'] ~> Class['vault::service']
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,8 @@ class vault::params {
 
   $manage_service = true
 
+  $mode               = 'server'
+
   case $::osfamily {
     'Debian': {
       case $::lsbdistcodename {


### PR DESCRIPTION
I find it convenient to use the same module to distribute the client, and without placing a bunch of unnecessary config.