### PR TITLE
Allow managing the service file when not included in repo installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `manage_backend_dir`: When using the file backend, this boolean determines whether or not the path (as specified in the `['file']['path']` section of the backend config) is created, and the owner and group set to the vault user.  Default: `false`
 
+* `manage_service_file`: Manages the service file regardless of the defaults. Default: See [Installation parameters](#installation-parameters).
+
 ### Installation parameters
 
 #### When `install_method` is `repo`
@@ -62,6 +64,7 @@ When `repo` is set the module will attempt to install a package corresponding wi
 * `package_name`:  Name of the package to install, default: `vault`
 * `package_ensure`: Desired state of the package, default: `installed`
 * `bin_dir`: Set to the path where the package will install the Vault binary, this is necessary to correctly manage the [`disable_mlock`](#mlock) option.
+* `manage_service_file`: Will manage the service file in case it's not included in the package, default: false
 
 #### When `install_method` is `archive`
 
@@ -75,6 +78,7 @@ The module will **not** manage any required packages to un-archive, e.g. `unzip`
 * `manage_download_dir`: Boolean, whether or not to create the download directory, default: `false`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
 * `version`: The Version of vault to download. default: `0.7.3`
+* `manage_service_file`: Will manage the service file. default: true
 
 ### Configuration parameters
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,21 @@ class vault::config {
     }
   }
 
-  if $::vault::install_method == 'archive' {
+  # If nothing is specified for manage_service_file, defaults will be used
+  # depending on the install_method.
+  # If a value is passed, it will be interpretted as a boolean.
+  if $::vault::manage_service_file == undef {
+    case $::vault::install_method {
+      'archive': { $real_manage_service_file = true  }
+      'repo':    { $real_manage_service_file = false }
+      default:   { $real_manage_service_file = false }
+    }
+  } else {
+    validate_bool($::vault::manage_service_file)
+    $real_manage_service_file = $::vault::manage_service_file
+  }
+
+  if $real_manage_service_file {
     case $::vault::service_provider {
       'upstart': {
         file { '/etc/init/vault.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,7 @@ class vault (
   $service_name        = $::vault::params::service_name,
   $service_provider    = $::vault::params::service_provider,
   $manage_service      = $::vault::params::manage_service,
+  $manage_service_file = $::vault::params::manage_service_file,
   $backend             = $::vault::params::backend,
   $manage_backend_dir  = $::vault::params::manage_backend_dir,
   $listener            = $::vault::params::listener,
@@ -126,9 +127,9 @@ class vault (
   $real_download_url    = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")
   # lint:endignore
 
-  contain vault::install
-  contain vault::config
-  contain vault::service
+  contain ::vault::install
+  contain ::vault::config
+  contain ::vault::service
 
   Class['vault::install'] -> Class['vault::config']
   Class['vault::config'] ~> Class['vault::service']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class vault::install {
 
     'repo': {
       package { $::vault::package_name:
-        ensure  => $::vault::package_ensure
+        ensure  => $::vault::package_ensure,
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class vault::params {
     'tcp' => {
       'address'     => '127.0.0.1:8200',
       'tls_disable' => 1,
-    }
+    },
   }
 
   # These should always be undef as they are optional settings that
@@ -45,6 +45,8 @@ class vault::params {
   $disable_mlock      = undef
 
   $manage_service = true
+
+  $manage_service_file = undef
 
   case $::osfamily {
     'Debian': {

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -226,6 +226,56 @@ describe 'vault' do
         is_expected.to_not contain_exec('systemd-reload')
       }
     end
+    context 'install through repo with default service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through repo without service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through repo with service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
+    end
+
+    context 'install through archive with default service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
+    end
+    context 'install through archive without service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through archive with service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
+    end
+
   end
   context 'RedHat 6 specific' do
     let(:facts) {{
@@ -280,6 +330,55 @@ describe 'vault' do
       it {
         is_expected.to_not contain_exec('systemd-reload')
       }
+    end
+    context 'install through repo with default service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through repo without service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through repo with service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
+    end
+
+    context 'install through archive with default service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
+    end
+    context 'install through archive without service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/init.d/vault') }
+    end
+    context 'install through archive with service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/init.d/vault') }
     end
   end
   context 'RedHat >=7 specific' do
@@ -374,6 +473,55 @@ describe 'vault' do
           .with_refreshonly(true)
       }
     end
+    context 'install through repo with default service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+    end
+    context 'install through repo without service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+    end
+    context 'install through repo with service management' do
+      let(:params) {{
+          :install_method      => 'repo',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+    end
+
+    context 'install through archive with default service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => :undef,
+      }}
+
+      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+    end
+    context 'install through archive without service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => false,
+      }}
+
+      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+    end
+    context 'install through archive with service management' do
+      let(:params) {{
+          :install_method      => 'archive',
+          :manage_service_file => true,
+      }}
+
+      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+    end
   end
   ['trusty','vivid'].each do |lsbdistcodename|
     context "Ubuntu-#{lsbdistcodename}-specific" do
@@ -441,6 +589,55 @@ describe 'vault' do
         }
         it { is_expected.to contain_user('root') }
         it { is_expected.to contain_group('admin') }
+      end
+      context 'install through repo with default service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => :undef,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/init.d/vault') }
+      end
+      context 'install through repo without service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => false,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/init.d/vault') }
+      end
+      context 'install through repo with service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => true,
+        }}
+
+        it { is_expected.to contain_file('/etc/init.d/vault') }
+      end
+
+      context 'install through archive with default service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => :undef,
+        }}
+
+        it { is_expected.to contain_file('/etc/init.d/vault') }
+      end
+      context 'install through archive without service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => false,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/init.d/vault') }
+      end
+      context 'install through archive with service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => true,
+        }}
+
+        it { is_expected.to contain_file('/etc/init.d/vault') }
       end
     end
   end
@@ -536,6 +733,55 @@ describe 'vault' do
                           .with_user('root')
                           .with_refreshonly(true)
         }
+      end
+      context 'install through repo with default service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => :undef,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+      end
+      context 'install through repo without service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => false,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+      end
+      context 'install through repo with service management' do
+        let(:params) {{
+            :install_method      => 'repo',
+            :manage_service_file => true,
+        }}
+
+        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+      end
+
+      context 'install through archive with default service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => :undef,
+        }}
+
+        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+      end
+      context 'install through archive without service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => false,
+        }}
+
+        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+      end
+      context 'install through archive with service management' do
+        let(:params) {{
+            :install_method      => 'archive',
+            :manage_service_file => true,
+        }}
+
+        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
       end
     end
   end


### PR DESCRIPTION
When selecting  'repo' as installation method, the module expects the package to include a service file.
That's not always the case.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>