### PR TITLE
Add proxy support to Vault service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `manage_service_file`: Manages the service file regardless of the defaults. Default: See [Installation parameters](#installation-parameters).
 
+* `manage_proxy`: Whether or not Puppet will set the HTTPS_PROXY variable for the service. Default: `false`
+
+* `proxy_address`: Address of the proxy to use, in the format 'proxy.domain.tld:8080'. 
+
 ### Installation parameters
 
 #### When `install_method` is `repo`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -88,6 +88,17 @@ class vault::config {
           content => template('vault/vault.systemd.erb'),
           notify  => Exec['systemd-reload'],
         }
+        if $::vault::manage_proxy == true {
+          file { '/etc/systemd/system/vault.service.d/10-proxy.conf':
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
+            content => "[Service]
+                        Environment=HTTPS_PROXY=${::vault::proxy_address}"
+            notify  => Exec['systemd-reload']
+          }
+        }
         if ! defined(Exec['systemd-reload']) {
           exec {'systemd-reload':
             command     => 'systemctl daemon-reload',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -95,8 +95,8 @@ class vault::config {
             group   => 'root',
             mode    => '0644',
             content => "[Service]
-                        Environment=HTTPS_PROXY=${::vault::proxy_address}"
-            notify  => Exec['systemd-reload']
+                        Environment=HTTPS_PROXY=${::vault::proxy_address}",
+            notify  => Exec['systemd-reload'],
           }
         }
         if ! defined(Exec['systemd-reload']) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,12 @@
 # * `manage_service`
 #   Instruct puppet to manage service or not
 #
+# * `manage_proxy`
+#   Instruct puppet to set proxy environment variables for the Vault service
+#
+# * `proxy_address`
+#   Address of the proxy to set for the Vault service
+#
 # * `num_procs`
 #   Sets the GOMAXPROCS environment variable, to determine how many CPUs Vault
 #   can use. The official Vault Terraform install.sh script sets this to the
@@ -75,6 +81,8 @@ class vault (
   $service_name        = $::vault::params::service_name,
   $service_provider    = $::vault::params::service_provider,
   $manage_service      = $::vault::params::manage_service,
+  $manage_proxy        = $::vault::params::manage_proxy,
+  $proxy_address       = $::vault::params::proxy_address,
   $manage_service_file = $::vault::params::manage_service_file,
   $backend             = $::vault::params::backend,
   $manage_backend_dir  = $::vault::params::manage_backend_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,8 @@ class vault::params {
   $disable_mlock      = undef
 
   $manage_service = true
-
+  $manage_proxy = false
+  $proxy_address = undef
   $manage_service_file = undef
 
   case $::osfamily {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,13 @@
 # == Class vault::service
 class vault::service {
   if $::vault::manage_service {
+    
+    if $::vault::manage_proxy {
+      if $::vault::proxy_address == undef {
+        fail("manage_proxy is true, but proxy address has not been set!")
+      }
+    }
+    
     service { $::vault::service_name:
       ensure   => running,
       enable   => true,

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -169,6 +169,22 @@ describe 'vault' do
             .with_group('vault')
         }
       end
+
+      context "when specifying manage_proxy" do
+        let(:params) {{
+          :manage_proxy => true,
+          :proxy_address => 'proxy.domain.local:8080'
+        }}
+        
+        it {
+          is_expected.to contain_file('/etc/systemd/system/vault.service.d/10-proxy.conf')
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group('root')
+            .with_content(/\[Service\]/)
+            .with_content(/\s*Environment=HTTPS_PROXY=proxy.domain.local:8080/)
+        }
+      end
     end
   end
   context 'RedHat 7 Amazon Linux specific' do

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -329,6 +329,8 @@ describe 'vault' do
         :user => 'root',
         :group => 'admin',
         :num_procs => '5',
+        :manage_proxy => true,
+        :proxy_address => 'proxy.domain.local:8080',
       }}
       it {
         is_expected.to contain_file('/etc/init.d/vault')
@@ -338,6 +340,7 @@ describe 'vault' do
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
           .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
+          .with_content(/export HTTPS_PROXY=proxy.domain.local:8080/)
           .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
           .with_content(%r{exec="/opt/bin/vault"})
@@ -492,6 +495,21 @@ describe 'vault' do
           .with_refreshonly(true)
       }
     end
+    context "when specifying manage_proxy" do
+      let(:params) {{
+        :manage_proxy => true,
+        :proxy_address => 'proxy.domain.local:8080'
+      }}
+
+      it {
+        is_expected.to contain_file('/etc/systemd/system/vault.service.d/10-proxy.conf')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_content(/\[Service\]/)
+          .with_content(/\s*Environment=HTTPS_PROXY=proxy.domain.local:8080/)
+      }
+    end
     context 'install through repo with default service management' do
       let(:params) {{
           :install_method      => 'repo',
@@ -583,6 +601,8 @@ describe 'vault' do
                         :service_options => '-log-level=info',
                         :user => 'root',
                         :group => 'admin',
+                        :manage_proxy => true,
+                        :proxy_address => 'proxy.domain.local:8080',
                       }}
         it {
           is_expected.to contain_file('/etc/init/vault.conf')
@@ -591,6 +611,7 @@ describe 'vault' do
                           .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
                           .with_content(/env VAULT=\/opt\/bin\/vault/)
                           .with_content(/start-stop-daemon .* -log-level=info$/)
+                          .with_content(/export HTTPS_PROXY=proxy.domain.local:8080/)                          
         }
         it {
           is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
@@ -801,6 +822,21 @@ describe 'vault' do
         }}
 
         it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+      end
+      context "when specifying manage_proxy" do
+        let(:params) {{
+          :manage_proxy => true,
+          :proxy_address => 'proxy.domain.local:8080'
+        }}
+
+        it {
+          is_expected.to contain_file('/etc/systemd/system/vault.service.d/10-proxy.conf')
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group('root')
+            .with_content(/\[Service\]/)
+            .with_content(/\s*Environment=HTTPS_PROXY=proxy.domain.local:8080/)
+        }
       end
     end
   end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -175,7 +175,7 @@ describe 'vault' do
           :manage_proxy => true,
           :proxy_address => 'proxy.domain.local:8080'
         }}
-        
+
         it {
           is_expected.to contain_file('/etc/systemd/system/vault.service.d/10-proxy.conf')
             .with_ensure('file')
@@ -221,6 +221,8 @@ describe 'vault' do
         :user => 'root',
         :group => 'admin',
         :num_procs => '5',
+        :manage_proxy => true,
+        :proxy_address => 'proxy.domain.local:8080',
       }}
       it {
         is_expected.to contain_file('/etc/init.d/vault')
@@ -230,6 +232,7 @@ describe 'vault' do
           .with_group('root')
           .with_content(%r{^#!/bin/sh})
           .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
+          .with_content(/export HTTPS_PROXY=proxy.domain.local:8080/)
           .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
           .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
           .with_content(%r{exec="/opt/bin/vault"})

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -51,6 +51,9 @@ start() {
     touch $logfile $pidfile
     chown <%= scope['vault::user'] %> $logfile $pidfile
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
+    <% if scope['vault::manage_proxy'] == true -%>
+    export HTTPS_PROXY=<%= scope['vault::proxy_address'] %>
+    <% end -%>
     daemon --user <%= scope['vault::user'] %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -16,6 +16,9 @@ env LOG_FILE=/var/log/vault.log
 
 script
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
+    <% if scope['vault::manage_proxy'] == true -%>
+    export HTTPS_PROXY=<%= scope['vault::proxy_address'] %>
+    <% end -%>
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
     exec >> $LOG_FILE 2>&1
     exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope['vault::service_options'] %>


### PR DESCRIPTION
##### SUMMARY

This change is to add the ability to manage the HTTPS_PROXY variable for the Vault service.

This is needed due to the fact that services will not honour other system environment variables, and in order to utilise the cloud storage (AWS, Azure) and certain dynamic secrets (IAM roles) behind a proxy that variable must be set within the service.

2 new class parameters have been added:
'manage_proxy' (Boolean)
'proxy_address' (String)

##### TESTS/SPECS

Tests have been updated to check for the environment variable being set in each OS already defined in the test set. 

Manual testing has been perform on CentOS7/Systemd, with automated tests passing in TravisCI.

