### PR TITLE
[WIP] Fix outdated systemd config parameter

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -1,0 +1,13 @@
+# Fact: systemd_version
+#
+# Purpose:
+#   Determine the version of systemd installed
+#
+# Resolution:
+#  Check the output of systemctl --version
+
+Facter.add(:systemd_version) do
+  setcode do
+    Facter::Util::Resolution.exec("systemctl --version")[/[0-9]+(\.[0-9]+)*/].to_i
+  end
+end

--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -7,6 +7,7 @@
 #  Check the output of systemctl --version
 
 Facter.add(:systemd_version) do
+  confine :systemd => true
   setcode do
     Facter::Util::Resolution.exec("systemctl --version")[/[0-9]+(\.[0-9]+)*/].to_i
   end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,6 +80,7 @@ class vault::config {
         }
       }
       'systemd': {
+        $systemd_version = $::systemd_version
         file { '/etc/systemd/system/vault.service':
           ensure  => file,
           owner   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,7 +80,7 @@ class vault::config {
         }
       }
       'systemd': {
-        $systemd_version = $::systemd_version
+        $systemd_version = $::vault::params::systemd_version
         file { '/etc/systemd/system/vault.service':
           ensure  => file,
           owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,7 @@ class vault (
   $version             = $::vault::params::version,
   $os                  = $::vault::params::os,
   $arch                = $::vault::params::arch,
+  $systemd_version     = $::vault::params::systemd_version,
   $extra_config        = {},
 ) inherits ::vault::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,12 +53,14 @@ class vault::params {
       case $::lsbdistcodename {
         /(jessie|stretch|sid|xenial|yakketi|zesty)/: {
           $service_provider = 'systemd'
+          $systemd_version  = $facts['systemd_version']
         }
         /(trusty|vivid)/: {
           $service_provider = 'upstart'
         }
         default: {
           $service_provider = 'systemd'
+          $systemd_version  = $facts['systemd_version']
           warning("Module ${module_name} is not supported on '${::lsbdistcodename}'")
         }
       }
@@ -68,6 +70,7 @@ class vault::params {
         $service_provider = 'redhat'
       } else {
         $service_provider = 'systemd'
+        $systemd_version  = $facts['systemd_version']
       }
     }
     default: {

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -390,7 +390,10 @@ describe 'vault' do
       :architecture              => 'x86_64',
       :kernel                    => 'Linux',
     }}
-    context 'includes systemd init script' do
+    context 'includes systemd init script with systemd_version < 229' do
+      let(:facts) {{
+                   :systemd_version => 228
+                    }}
       it {
         is_expected.to contain_file('/etc/systemd/system/vault.service')
           .with_mode('0644')
@@ -405,6 +408,50 @@ describe 'vault' do
           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
           .with_content(/SecureBits=keep-caps/)
           .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+          .with_content(/NoNewPrivileges=yes/)
+      }
+    end
+    context 'includes systemd init script with systemd_version = 229' do
+      let(:facts) {{
+                   :systemd_version => 229
+                    }}
+      it {
+        is_expected.to contain_file('/etc/systemd/system/vault.service')
+          .with_mode('0644')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_notify('Exec[systemd-reload]')
+          .with_content(/^# vault systemd unit file/)
+          .with_content(/^User=vault$/)
+          .with_content(/^Group=vault$/)
+          .with_content(/Environment=GOMAXPROCS=3/)
+          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+          .with_content(/SecureBits=keep-caps/)
+          .with_content(/AmbientCapabilities=CAP_IPC_LOCK/)
+          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+          .with_content(/NoNewPrivileges=yes/)
+      }
+    end
+    context 'includes systemd init script with systemd_version > 229' do
+      let(:facts) {{
+                   :systemd_version => 230
+                    }}
+      it {
+        is_expected.to contain_file('/etc/systemd/system/vault.service')
+          .with_mode('0644')
+          .with_ensure('file')
+          .with_owner('root')
+          .with_group('root')
+          .with_notify('Exec[systemd-reload]')
+          .with_content(/^# vault systemd unit file/)
+          .with_content(/^User=vault$/)
+          .with_content(/^Group=vault$/)
+          .with_content(/Environment=GOMAXPROCS=3/)
+          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+          .with_content(/SecureBits=keep-caps/)
+          .with_content(/AmbientCapabilities=CAP_IPC_LOCK/)
           .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
           .with_content(/NoNewPrivileges=yes/)
       }
@@ -459,6 +506,7 @@ describe 'vault' do
           .with_content(/^Group=vault$/)
           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
           .without_content(/SecureBits=keep-caps/)
+          .without_content(/AmbientCapabilities=CAP_IPC_LOCK/)
           .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
           .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
           .with_content(/NoNewPrivileges=yes/)
@@ -651,23 +699,70 @@ describe 'vault' do
                      :architecture    => 'x86_64',
                      :kernel          => 'Linux',
                    }}
-      context 'includes systemd init script' do
+      context 'includes systemd init script with systemd_version < 229' do
+        let(:facts) {{
+                     :systemd_version => 228
+                      }}
         it {
           is_expected.to contain_file('/etc/systemd/system/vault.service')
-                          .with_mode('0644')
-                          .with_ensure('file')
-                          .with_owner('root')
-                          .with_group('root')
-                          .with_notify('Exec[systemd-reload]')
-                          .with_content(/^# vault systemd unit file/)
-                          .with_content(/^User=vault$/)
-                          .with_content(/^Group=vault$/)
-                          .with_content(/Environment=GOMAXPROCS=3/)
-                          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                          .with_content(/SecureBits=keep-caps/)
-                          .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
-                          .with_content(/NoNewPrivileges=yes/)
+            .with_mode('0644')
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group('root')
+            .with_notify('Exec[systemd-reload]')
+            .with_content(/^# vault systemd unit file/)
+            .with_content(/^User=vault$/)
+            .with_content(/^Group=vault$/)
+            .with_content(/Environment=GOMAXPROCS=3/)
+            .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+            .with_content(/SecureBits=keep-caps/)
+            .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+            .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+            .with_content(/NoNewPrivileges=yes/)
+        }
+      end
+      context 'includes systemd init script with systemd_version = 229' do
+        let(:facts) {{
+                     :systemd_version => 229
+                      }}
+        it {
+          is_expected.to contain_file('/etc/systemd/system/vault.service')
+            .with_mode('0644')
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group('root')
+            .with_notify('Exec[systemd-reload]')
+            .with_content(/^# vault systemd unit file/)
+            .with_content(/^User=vault$/)
+            .with_content(/^Group=vault$/)
+            .with_content(/Environment=GOMAXPROCS=3/)
+            .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+            .with_content(/SecureBits=keep-caps/)
+            .with_content(/AmbientCapabilities=CAP_IPC_LOCK/)
+            .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+            .with_content(/NoNewPrivileges=yes/)
+        }
+      end
+      context 'includes systemd init script with systemd_version > 229' do
+        let(:facts) {{
+                     :systemd_version => 230
+                      }}
+        it {
+          is_expected.to contain_file('/etc/systemd/system/vault.service')
+            .with_mode('0644')
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group('root')
+            .with_notify('Exec[systemd-reload]')
+            .with_content(/^# vault systemd unit file/)
+            .with_content(/^User=vault$/)
+            .with_content(/^Group=vault$/)
+            .with_content(/Environment=GOMAXPROCS=3/)
+            .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+            .with_content(/SecureBits=keep-caps/)
+            .with_content(/AmbientCapabilities=CAP_IPC_LOCK/)
+            .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+            .with_content(/NoNewPrivileges=yes/)
         }
       end
       context 'service with non-default options' do
@@ -721,6 +816,7 @@ describe 'vault' do
                           .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
                           .without_content(/SecureBits=keep-caps/)
                           .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+                          .without_content(/AmbientCapabilities=CAP_IPC_LOCK/)
                           .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
                           .with_content(/NoNewPrivileges=yes/)
         }

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -23,11 +23,7 @@ CapabilityBoundingSet=CAP_SYSLOG
 NoNewPrivileges=yes
 <% else -%>
 SecureBits=keep-caps
-<<<<<<< HEAD
-<% if @facts['systemd_version'] > 229 -%>
-=======
-<% if scope['::systemd_version'] > 229 -%>
->>>>>>> ca14090... fixup
+<% if scope['vault::systemd_version'] > 229 -%>
 AmbientCapabilities=CAP_IPC_LOCK
 <% else -%>
 Capabilities=CAP_IPC_LOCK+ep

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -23,7 +23,15 @@ CapabilityBoundingSet=CAP_SYSLOG
 NoNewPrivileges=yes
 <% else -%>
 SecureBits=keep-caps
+<<<<<<< HEAD
+<% if @facts['systemd_version'] > 229 -%>
+=======
+<% if scope['::systemd_version'] > 229 -%>
+>>>>>>> ca14090... fixup
+AmbientCapabilities=CAP_IPC_LOCK
+<% else -%>
 Capabilities=CAP_IPC_LOCK+ep
+<% end -%>
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
 <% end -%>


### PR DESCRIPTION
##### SUMMARY
Capabilities is succeeded by AmbientCapabilities in Systemd. Debian 9 on 4.9.0-4-amd64 running systemd 232-25+deb9u1 displays: 

`[/etc/systemd/system/vault.service:21] Support for option Capabilities= has been removed and it is ignored`

Therefore it is not possible to start the Systemd service with mlock support enabled:
`systemd[4092]: vault.service: Failed at step SECUREBITS spawning /usr/local/bin/vault: Operation not permitted
vault.service: Main process exited, code=exited, status=213/SECUREBITS`

##### TESTS/SPECS
This has change been tested on my local vault server. The service starts and Vault is confirming that mlock.
`vault[18669]:  Mlock: supported: true, enabled: true`
