### PR TITLE
Fix for setcap happening before install

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,9 +41,10 @@ class vault::install {
 
   if !$::vault::disable_mlock {
     exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
-      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
-      subscribe => File[$vault_bin],
-      unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
+      path        => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
+      subscribe   => File[$vault_bin],
+      unless      => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
+      refreshonly => true,
     }
   }
 


### PR DESCRIPTION
Fixes #92 

##### SUMMARY
Setcap happens before the install is completed unless you set `refreshonly` on the `exec`.

##### TESTS/SPECS

Tested this change by creating a new vault server and letting puppet run automatically. Before this change it would fail the first run, and then succeed the second. Now it works properly the first time.
