### PR TITLE
use service_provider fact to determine init system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 script: bundle exec rake test
 matrix:
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.8.0" LEGACY=yes
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.9" DEPLOY_CANDIDATE=yes
   - sudo: required
@@ -30,8 +28,6 @@ matrix:
     bundler_args: --without development
   - rvm: 2.4.0
     env: PUPPET_GEM_VERSION="~> 4" FUTURE=yes
-  allow_failures:
-  - rvm: 1.9.3
 deploy:
   provider: puppetforge
   user: jsok

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -97,7 +97,7 @@ class vault::config {
           }
         }
       }
-      'redhat': {
+      /(redhat|sysv)/: {
         file { '/etc/init.d/vault':
           ensure  => file,
           owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,32 +48,8 @@ class vault::params {
 
   $manage_service_file = undef
 
-  case $::osfamily {
-    'Debian': {
-      case $::lsbdistcodename {
-        /(jessie|stretch|sid|xenial|yakketi|zesty)/: {
-          $service_provider = 'systemd'
-        }
-        /(trusty|vivid)/: {
-          $service_provider = 'upstart'
-        }
-        default: {
-          $service_provider = 'systemd'
-          warning("Module ${module_name} is not supported on '${::lsbdistcodename}'")
-        }
-      }
-    }
-    'RedHat': {
-      if ($::operatingsystemmajrelease == '6' or $::operatingsystem == 'Amazon') {
-        $service_provider = 'redhat'
-      } else {
-        $service_provider = 'systemd'
-      }
-    }
-    default: {
-      fail("Module ${module_name} is not supported on osfamily '${::osfamily}'")
-    }
-  }
+  $service_provider = $facts['service_provider']
+
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }
     'i386':            { $arch = '386'   }

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.2.0 < 5.0.0"
+      "version_requirement": ">= 4.10.0 < 5.0.0"
     },
     {
       "name": "puppet-archive",

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -9,6 +9,7 @@ describe 'vault' do
         :processorcount => '3',
         :architecture   => 'x86_64',
         :kernel         => 'Linux',
+        :service_provider => 'systemd',
       }}
 
       context "vault class with simple configuration" do
@@ -180,6 +181,7 @@ describe 'vault' do
       :processorcount            => '3',
       :architecture              => 'x86_64',
       :kernel                    => 'Linux',
+      :service_provider          => 'sysv',
    }}
    context 'includes SysV init script' do
       it {
@@ -285,6 +287,7 @@ describe 'vault' do
       :processorcount            => '3',
       :architecture              => 'x86_64',
       :kernel                    => 'Linux',
+      :service_provider          => 'sysv',
     }}
     context 'includes SysV init script' do
       it {
@@ -389,6 +392,7 @@ describe 'vault' do
       :processorcount            => '3',
       :architecture              => 'x86_64',
       :kernel                    => 'Linux',
+      :service_provider          => 'systemd',
     }}
     context 'includes systemd init script' do
       it {
@@ -532,6 +536,7 @@ describe 'vault' do
                      :processorcount  => '3',
                      :architecture    => 'x86_64',
                      :kernel          => 'Linux',
+                     :service_provider => 'upstart',
                    }}
       context 'includes init link to upstart-job' do
         it {
@@ -650,6 +655,7 @@ describe 'vault' do
                      :processorcount  => '3',
                      :architecture    => 'x86_64',
                      :kernel          => 'Linux',
+                     :service_provider => 'systemd',
                    }}
       context 'includes systemd init script' do
         it {
@@ -793,6 +799,7 @@ describe 'vault' do
       :processorcount            => '3',
       :architecture              => 'x86_64',
       :kernel                    => 'Linux',
+      :service_provider          => 'systemd',
     }}
     let(:params) {{
       :service_provider => 'foo',
@@ -803,15 +810,5 @@ describe 'vault' do
           .to raise_error(Puppet::Error, /vault::service_provider 'foo' is not valid/)
       }
     end
-  end
-  context 'on unsupported osfamily' do
-    let(:facts) {{
-      :path           => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily       => 'nexenta',
-      :processorcount => '3',
-    }}
-    it {
-      expect { should contain_class('vault') }.to raise_error(Puppet::Error, /Module vault is not supported on osfamily 'nexenta'/)
-    }
   end
 end


### PR DESCRIPTION
puppetlabs-stdlib provides the fact service_provider since 4.10.0. We
can rely on the fact, instead of implementing own logic.

