### PR TITLE
set sane mode for vault binary

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,7 +36,7 @@ class vault::install {
   file { $vault_bin:
     owner => 'root',
     group => 'root',
-    mode  => '0555',
+    mode  => '0755',
   }
 
   if !$::vault::disable_mlock {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -40,7 +40,7 @@ describe 'vault class' do
 
     describe file('/usr/local/bin/vault') do
       it { is_expected.to exist }
-      it { is_expected.to be_mode 555 }
+      it { is_expected.to be_mode 755 }
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
     end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -70,7 +70,7 @@ describe 'vault' do
             .with_content(/"tls_disable":\s*1/)
         }
 
-        it { is_expected.to contain_file('/usr/local/bin/vault').with_mode('0555') }
+        it { is_expected.to contain_file('/usr/local/bin/vault').with_mode('0755') }
         it {
           is_expected.to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault')
             .with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep')
@@ -585,7 +585,7 @@ describe 'vault' do
         }
         it { is_expected.to contain_file('/opt/etc/vault/config.json') }
 
-        it { is_expected.to contain_file('/opt/bin/vault').with_mode('0555') }
+        it { is_expected.to contain_file('/opt/bin/vault').with_mode('0755') }
         it {
           is_expected.to contain_file('/opt/etc/vault')
                           .with_ensure('directory')


### PR DESCRIPTION
at least the root user should have executeable permissions
