### PR TITLE
drop unneeded/broken systemd options

### DIFF
--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -13,7 +13,6 @@ After=basic.target network.target
 [Service]
 User=<%= scope['vault::user'] %>
 Group=<%= scope['vault::group'] %>
-PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=read-only
@@ -22,10 +21,7 @@ ProtectHome=read-only
 CapabilityBoundingSet=CAP_SYSLOG
 NoNewPrivileges=yes
 <% else -%>
-SecureBits=keep-caps
-Capabilities=CAP_IPC_LOCK+ep
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
-NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_IPC_LOCK
 <% end -%>
 Environment=GOMAXPROCS=<%= scope['vault::num_procs'] %>
 ExecStart=<%= scope['vault::bin_dir'] %>/vault server -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>


### PR DESCRIPTION
at least on systemd235, PrivateDevices=yes doesn't work together with
the CAP_IPC_LOCK. The CAP_SYSLOG capability isn't needed. Capabilities=
is deprecated.
