### PR TITLE
migrate to rspec-puppet-facts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,545 @@
+require: rubocop-rspec
+AllCops:
+  TargetRubyVersion: 1.9
+  Include:
+    - ./**/*.rb
+  Exclude:
+    - files/**/*
+    - vendor/**/*
+    - .vendor/**/*
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - Gemfile
+    - Rakefile
+    - Guardfile
+    - Vagrantfile
+Lint/ConditionPosition:
+  Enabled: True
+
+Lint/ElseLayout:
+  Enabled: True
+
+Lint/UnreachableCode:
+  Enabled: True
+
+Lint/UselessComparison:
+  Enabled: True
+
+Lint/EnsureReturn:
+  Enabled: True
+
+Lint/HandleExceptions:
+  Enabled: True
+
+Lint/LiteralInCondition:
+  Enabled: True
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: True
+
+Lint/LiteralInInterpolation:
+  Enabled: True
+
+Style/HashSyntax:
+  Enabled: True
+
+Style/RedundantReturn:
+  Enabled: True
+
+Style/EndOfLine:
+  Enabled: False
+
+Lint/AmbiguousOperator:
+  Enabled: True
+
+Lint/AssignmentInCondition:
+  Enabled: True
+
+Layout/SpaceBeforeComment:
+  Enabled: True
+
+Style/AndOr:
+  Enabled: True
+
+Style/RedundantSelf:
+  Enabled: True
+
+Metrics/BlockLength:
+  Enabled: False
+
+# Method length is not necessarily an indicator of code quality
+Metrics/MethodLength:
+  Enabled: False
+
+# Module length is not necessarily an indicator of code quality
+Metrics/ModuleLength:
+  Enabled: False
+
+Style/WhileUntilModifier:
+  Enabled: True
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: True
+
+Security/Eval:
+  Enabled: True
+
+Lint/BlockAlignment:
+  Enabled: True
+
+Lint/DefEndAlignment:
+  Enabled: True
+
+Lint/EndAlignment:
+  Enabled: True
+
+Lint/DeprecatedClassMethods:
+  Enabled: True
+
+Lint/Loop:
+  Enabled: True
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: True
+
+Lint/RescueException:
+  Enabled: True
+
+Lint/StringConversionInInterpolation:
+  Enabled: True
+
+Lint/UnusedBlockArgument:
+  Enabled: True
+
+Lint/UnusedMethodArgument:
+  Enabled: True
+
+Lint/UselessAccessModifier:
+  Enabled: True
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Lint/Void:
+  Enabled: True
+
+Layout/AccessModifierIndentation:
+  Enabled: True
+
+Style/AccessorMethodName:
+  Enabled: True
+
+Style/Alias:
+  Enabled: True
+
+Layout/AlignArray:
+  Enabled: True
+
+Layout/AlignHash:
+  Enabled: True
+
+Layout/AlignParameters:
+  Enabled: True
+
+Metrics/BlockNesting:
+  Enabled: True
+
+Style/AsciiComments:
+  Enabled: True
+
+Style/Attr:
+  Enabled: True
+
+Style/BracesAroundHashParameters:
+  Enabled: True
+
+Style/CaseEquality:
+  Enabled: True
+
+Layout/CaseIndentation:
+  Enabled: True
+
+Style/CharacterLiteral:
+  Enabled: True
+
+Style/ClassAndModuleCamelCase:
+  Enabled: True
+
+Style/ClassAndModuleChildren:
+  Enabled: False
+
+Style/ClassCheck:
+  Enabled: True
+
+# Class length is not necessarily an indicator of code quality
+Metrics/ClassLength:
+  Enabled: False
+
+Style/ClassMethods:
+  Enabled: True
+
+Style/ClassVars:
+  Enabled: True
+
+Style/WhenThen:
+  Enabled: True
+
+Style/WordArray:
+  Enabled: True
+
+Style/UnneededPercentQ:
+  Enabled: True
+
+Layout/Tab:
+  Enabled: True
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: True
+
+Layout/TrailingBlankLines:
+  Enabled: True
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: True
+
+Layout/SpaceInsideBrackets:
+  Enabled: True
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: True
+
+Layout/SpaceInsideParens:
+  Enabled: True
+
+Layout/LeadingCommentSpace:
+  Enabled: True
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: True
+
+Layout/SpaceAfterColon:
+  Enabled: True
+
+Layout/SpaceAfterComma:
+  Enabled: True
+
+Layout/SpaceAfterMethodName:
+  Enabled: True
+
+Layout/SpaceAfterNot:
+  Enabled: True
+
+Layout/SpaceAfterSemicolon:
+  Enabled: True
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: True
+
+Layout/SpaceAroundOperators:
+  Enabled: True
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: True
+
+Layout/SpaceBeforeComma:
+  Enabled: True
+
+Style/CollectionMethods:
+  Enabled: True
+
+Layout/CommentIndentation:
+  Enabled: True
+
+Style/ColonMethodCall:
+  Enabled: True
+
+Style/CommentAnnotation:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/CyclomaticComplexity:
+  Enabled: False
+
+Style/ConstantName:
+  Enabled: True
+
+Style/Documentation:
+  Enabled: False
+
+Style/DefWithParentheses:
+  Enabled: True
+
+Style/PreferredHashMethods:
+  Enabled: True
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Style/DoubleNegation:
+  Enabled: True
+
+Style/EachWithObject:
+  Enabled: True
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: True
+
+Layout/IndentArray:
+  Enabled: True
+
+Layout/IndentHash:
+  Enabled: True
+
+Layout/IndentationConsistency:
+  Enabled: True
+
+Layout/IndentationWidth:
+  Enabled: True
+
+Layout/EmptyLines:
+  Enabled: True
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: True
+
+Style/EmptyLiteral:
+  Enabled: True
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Enabled: False
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: True
+
+Style/MethodDefParentheses:
+  Enabled: True
+
+Style/LineEndConcatenation:
+  Enabled: True
+
+Layout/TrailingWhitespace:
+  Enabled: True
+
+Style/StringLiterals:
+  Enabled: True
+
+Style/TrailingCommaInArguments:
+  Enabled: True
+
+Style/TrailingCommaInLiteral:
+  Enabled: True
+
+Style/GlobalVars:
+  Enabled: True
+
+Style/GuardClause:
+  Enabled: True
+
+Style/IfUnlessModifier:
+  Enabled: True
+
+Style/MultilineIfThen:
+  Enabled: True
+
+Style/NegatedIf:
+  Enabled: True
+
+Style/NegatedWhile:
+  Enabled: True
+
+Style/Next:
+  Enabled: True
+
+Style/SingleLineBlockParams:
+  Enabled: True
+
+Style/SingleLineMethods:
+  Enabled: True
+
+Style/SpecialGlobalVars:
+  Enabled: True
+
+Style/TrivialAccessors:
+  Enabled: True
+
+Style/UnlessElse:
+  Enabled: True
+
+Style/VariableInterpolation:
+  Enabled: True
+
+Style/VariableName:
+  Enabled: True
+
+Style/WhileUntilDo:
+  Enabled: True
+
+Style/EvenOdd:
+  Enabled: True
+
+Style/FileName:
+  Enabled: True
+
+Style/For:
+  Enabled: True
+
+Style/Lambda:
+  Enabled: True
+
+Style/MethodName:
+  Enabled: True
+
+Style/MultilineTernaryOperator:
+  Enabled: True
+
+Style/NestedTernaryOperator:
+  Enabled: True
+
+Style/NilComparison:
+  Enabled: True
+
+Style/FormatString:
+  Enabled: True
+
+Style/MultilineBlockChain:
+  Enabled: True
+
+Style/Semicolon:
+  Enabled: True
+
+Style/SignalException:
+  Enabled: True
+
+Style/NonNilCheck:
+  Enabled: True
+
+Style/Not:
+  Enabled: True
+
+Style/NumericLiterals:
+  Enabled: True
+
+Style/OneLineConditional:
+  Enabled: True
+
+Style/OpMethod:
+  Enabled: True
+
+Style/ParenthesesAroundCondition:
+  Enabled: True
+
+Style/PercentLiteralDelimiters:
+  Enabled: True
+
+Style/PerlBackrefs:
+  Enabled: True
+
+Style/PredicateName:
+  Enabled: True
+
+Style/RedundantException:
+  Enabled: True
+
+Style/SelfAssignment:
+  Enabled: True
+
+Style/Proc:
+  Enabled: True
+
+Style/RaiseArgs:
+  Enabled: True
+
+Style/RedundantBegin:
+  Enabled: True
+
+Style/RescueModifier:
+  Enabled: True
+
+# based on https://github.com/voxpupuli/modulesync_config/issues/168
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+  Enabled: True
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: True
+
+Metrics/ParameterLists:
+  Enabled: False
+
+Lint/RequireParentheses:
+  Enabled: True
+
+Style/ModuleFunction:
+  Enabled: True
+
+Lint/Debugger:
+  Enabled: True
+
+Style/IfWithSemicolon:
+  Enabled: True
+
+Style/Encoding:
+  Enabled: True
+
+Style/BlockDelimiters:
+  Enabled: True
+
+Layout/MultilineBlockLayout:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/AbcSize:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/PerceivedComplexity:
+  Enabled: False
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: True
+
+# RSpec
+
+RSpec/BeforeAfterAll:
+  Exclude:
+    - spec/acceptance/**/*
+
+# We don't use rspec in this way
+RSpec/DescribeClass:
+  Enabled: False
+
+# Example length is not necessarily an indicator of code quality
+RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/NamedSubject:
+  Enabled: False
+
+# disabled for now since they cause a lot of issues
+# these issues aren't easy to fix
+RSpec/RepeatedDescription:
+  Enabled: False
+
+RSpec/NestedGroups:
+  Enabled: False
+
+# this is broken on ruby1.9
+Layout/IndentHeredoc:
+  Enabled: False
+
+# disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
+Security/YAMLLoad:
+  Enabled: false
+
+# This affects hiera interpolation, as well as some configs that we push.
+Style/FormatStringToken:
+  Enabled: false
+
+# This is useful, but sometimes a little too picky about where unit tests files
+# are located.
+RSpec/FilePath:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,10 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
-  gem 'puppetlabs_spec_helper', '2.2.0',                            :require => false
-  gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppetlabs_spec_helper', '~> 2.5.0',                         :require => false
+  gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
-  gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
   gem 'puppet-lint-version_comparison-check',                       :require => false
@@ -13,15 +12,15 @@ group :test do
   gem 'puppet-lint-unquoted_string-check',                          :require => false
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
   gem 'metadata-json-lint',                                         :require => false
-  gem 'puppet-strings', '1.1.0',                                    :require => false
-  gem 'puppet_facts',                                               :require => false
-  gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
-  gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
-  gem 'safe_yaml', '~> 1.0.4',                                      :require => false
-  gem 'listen', '<= 3.0.6',                                         :require => false
-  gem 'puppet-syntax',                                              :require => false, git: 'https://github.com/gds-operations/puppet-syntax.git'
-  gem 'pry'
-  gem 'rb-readline'
+  gem 'redcarpet',                                                  :require => false
+  gem 'rubocop', '~> 0.49.1',                                       :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop-rspec', '~> 1.15.0',                                 :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'mocha', '>= 1.2.1',                                          :require => false
+  gem 'coveralls',                                                  :require => false
+  gem 'simplecov-console',                                          :require => false
+  gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
+  gem 'parallel_tests',                                             :require => false
+  gem 'fakefs',                                                     :require => false
 end
 
 group :development do
@@ -30,9 +29,9 @@ group :development do
 end
 
 group :system_tests do
-  gem "beaker", '2.41.0', :require => false
-  gem "beaker-rspec", '5.6.0', :require => false
-  gem 'beaker-puppet_install_helper',  :require => false
+  gem "beaker", '~> 3',               :require => false
+  gem "beaker-rspec", '~> 6',         :require => false
+  gem 'beaker-puppet_install_helper', :require => false
 end
 
 ENV['PUPPET_GEM_VERSION'].nil? ? puppetversion = '~> 5' : puppetversion = ENV['PUPPET_GEM_VERSION'].to_s

--- a/lib/puppet/parser/functions/vault_sorted_json.rb
+++ b/lib/puppet/parser/functions/vault_sorted_json.rb
@@ -2,39 +2,41 @@ require 'json'
 
 def sorted_json(obj)
   case obj
-    when Integer, Float, TrueClass, FalseClass, NilClass
-      return obj.to_json
-    when String
-      # Convert quoted integers (string) to int
-      return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
-    when Array
-      arrayRet = []
-      obj.each do |a|
-        arrayRet.push(sorted_json(a))
-      end
-      return "[" << arrayRet.join(',') << "]";
-    when Hash
-      ret = []
-      obj.keys.sort.each do |k|
-        ret.push(k.to_json << ":" << sorted_json(obj[k]))
-      end
-      return "{" << ret.join(",") << "}";
-    else
-      raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+  when Integer, Float, TrueClass, FalseClass, NilClass
+    return obj.to_json
+  when String
+    # Convert quoted integers (string) to int
+    (obj =~ %r{\A[-]?[0-9]+\z} ? obj.to_i : obj).to_json
+  when Array
+    arrayRet = []
+    obj.each do |a|
+      arrayRet.push(sorted_json(a))
+    end
+    '[' << arrayRet.join(',') << ']'
+  when Hash
+    ret = []
+    obj.keys.sort.each do |k|
+      ret.push(k.to_json << ':' << sorted_json(obj[k]))
+    end
+    '{' << ret.join(',') << '}'
+  else
+    raise Exception(format('Unable to handle object of type <%s>', obj.class.to_s))
   end
 end
 
 module Puppet::Parser::Functions
-  newfunction(:vault_sorted_json, :type => :rvalue, :doc => <<-EOS
+  newfunction(:vault_sorted_json, type: :rvalue, doc: <<-EOS
 This function takes data, outputs making sure the hash keys are sorted
 *Examples:*
     sorted_json({'key'=>'value'})
 Would return: {'key':'value'}
     EOS
-  ) do |arguments|
-    raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
-    json = arguments[0].delete_if {|key, value| value == :undef }
+             ) do |arguments|
+    if arguments.size != 1
+      raise(Puppet::ParseError, 'sorted_json(): Wrong number of arguments ' \
+        "given (#{arguments.size} for 1)")
+    end
+    json = arguments[0].delete_if { |_key, value| value == :undef }
     return sorted_json(json)
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -97,7 +97,7 @@ class vault::config {
           }
         }
       }
-      /(redhat|sysv)/: {
+      /(redhat|sysv|init)/: {
         file { '/etc/init.d/vault':
           ensure  => file,
           owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,66 +62,42 @@
 #   The version of Vault to install
 #
 class vault (
-  $user                = $::vault::params::user,
-  $manage_user         = $::vault::params::manage_user,
-  $group               = $::vault::params::group,
-  $manage_group        = $::vault::params::manage_group,
-  $bin_dir             = $::vault::params::bin_dir,
-  $config_dir          = $::vault::params::config_dir,
-  $purge_config_dir    = true,
-  $download_url        = $::vault::params::download_url,
-  $download_url_base   = $::vault::params::download_url_base,
-  $download_extension  = $::vault::params::download_extension,
-  $service_name        = $::vault::params::service_name,
-  $service_provider    = $::vault::params::service_provider,
-  $manage_service      = $::vault::params::manage_service,
-  $manage_service_file = $::vault::params::manage_service_file,
-  $storage             = $::vault::params::storage,
-  $manage_storage_dir  = $::vault::params::manage_storage_dir,
-  $listener            = $::vault::params::listener,
-  $ha_storage          = $::vault::params::ha_storage,
-  $disable_cache       = $::vault::params::disable_cache,
-  $telemetry           = $::vault::params::telemetry,
-  $default_lease_ttl   = $::vault::params::default_lease_ttl,
-  $max_lease_ttl       = $::vault::params::max_lease_ttl,
-  $disable_mlock       = $::vault::params::disable_mlock,
-  $service_options     = '',
-  $num_procs           = $::vault::params::num_procs,
-  $install_method      = $::vault::params::install_method,
-  $package_name        = $::vault::params::package_name,
-  $package_ensure      = $::vault::params::package_ensure,
-  $download_dir        = $::vault::params::download_dir,
-  $manage_download_dir = $::vault::params::manage_download_dir,
-  $download_filename   = $::vault::params::download_filename,
-  $version             = $::vault::params::version,
-  $os                  = $::vault::params::os,
-  $arch                = $::vault::params::arch,
-  $extra_config        = {},
+  $user                               = $::vault::params::user,
+  $manage_user                        = $::vault::params::manage_user,
+  $group                              = $::vault::params::group,
+  $manage_group                       = $::vault::params::manage_group,
+  $bin_dir                            = $::vault::params::bin_dir,
+  $config_dir                         = $::vault::params::config_dir,
+  $purge_config_dir                   = true,
+  $download_url                       = $::vault::params::download_url,
+  $download_url_base                  = $::vault::params::download_url_base,
+  $download_extension                 = $::vault::params::download_extension,
+  $service_name                       = $::vault::params::service_name,
+  $service_provider                   = $::vault::params::service_provider,
+  $manage_service                     = $::vault::params::manage_service,
+  $manage_service_file                = $::vault::params::manage_service_file,
+  Hash $storage                       = $::vault::params::storage,
+  $manage_storage_dir                 = $::vault::params::manage_storage_dir,
+  Hash $listener                      = $::vault::params::listener,
+  Optional[Hash] $ha_storage          = $::vault::params::ha_storage,
+  Optional[Boolean] $disable_cache    = $::vault::params::disable_cache,
+  Optional[Hash] $telemetry           = $::vault::params::telemetry,
+  Optional[String] $default_lease_ttl = $::vault::params::default_lease_ttl,
+  Optional[String] $max_lease_ttl     = $::vault::params::max_lease_ttl,
+  $disable_mlock                      = $::vault::params::disable_mlock,
+  $service_options                    = '',
+  $num_procs                          = $::vault::params::num_procs,
+  $install_method                     = $::vault::params::install_method,
+  $package_name                       = $::vault::params::package_name,
+  $package_ensure                     = $::vault::params::package_ensure,
+  $download_dir                       = $::vault::params::download_dir,
+  $manage_download_dir                = $::vault::params::manage_download_dir,
+  $download_filename                  = $::vault::params::download_filename,
+  $version                            = $::vault::params::version,
+  $os                                 = $::vault::params::os,
+  $arch                               = $::vault::params::arch,
+  Hash $extra_config                  = {},
 ) inherits ::vault::params {
-
-  validate_hash($storage)
-  validate_hash($listener)
-  validate_hash($extra_config)
-
-  if $ha_storage {
-    validate_hash($ha_storage)
-  }
-
-  if $disable_cache {
-    validate_bool($disable_cache)
-  }
-
-  if $telemetry {
-    validate_hash($telemetry)
-  }
-
-  if $default_lease_ttl {
-    validate_string($default_lease_ttl)
-  }
-
-  if $max_lease_ttl {
-    validate_string($max_lease_ttl)
-  }
 
   # lint:ignore:140chars
   $real_download_url    = pick($download_url, "${download_url_base}${version}/${package_name}_${version}_${os}_${arch}.${download_extension}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,8 @@ class vault::params {
   $download_extension = 'zip'
   $version            = '0.8.3'
   $service_name       = 'vault'
-  $num_procs          = $::processorcount
+  $num_procs          = $facts['processorcount']
+  $install_method     = 'archive'
   $package_name       = 'vault'
   $package_ensure     = 'installed'
 
@@ -46,17 +47,14 @@ class vault::params {
 
   $service_provider = $facts['service_provider']
 
-  case $::architecture {
-    'x86_64', 'amd64': { $arch = 'amd64' }
-    'i386':            { $arch = '386'   }
-    /^arm.*/:          { $arch = 'arm'   }
-    default:           {
-      fail("Unsupported kernel architecture: ${::architecture}")
-    }
+  case $facts['architecture'] {
+    /(x86_64|amd64)/: { $arch = 'amd64' }
+    'i386':           { $arch = '386'   }
+    /^arm.*/:         { $arch = 'arm'   }
+    default:          { fail("Unsupported kernel architecture: ${facts['architecture']}") }
   }
-  $os = downcase($::kernel)
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Archlinux': {
       $install_method      = 'repo'
       $bin_dir             = '/bin'
@@ -68,4 +66,5 @@ class vault::params {
       $manage_service_file = undef
     }
   }
+  $os = downcase($facts['kernel'])
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,6 @@ class vault::params {
   $version            = '0.8.3'
   $service_name       = 'vault'
   $num_procs          = $facts['processorcount']
-  $install_method     = 'archive'
   $package_name       = 'vault'
   $package_ensure     = 'installed'
 

--- a/metadata.json
+++ b/metadata.json
@@ -33,8 +33,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper_acceptance'
 
 describe 'vault class' do
-
   context 'default parameters' do
     # Using puppet_apply as a helper
-    it 'should work idempotently with no errors' do
+    it 'works idempotently with no errors' do
       pp = <<-EOS
       class { '::vault':
         storage => {
@@ -21,8 +20,8 @@ describe 'vault class' do
       }
       EOS
       # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes  => true)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
 
     describe user('vault') do
@@ -45,7 +44,7 @@ describe 'vault class' do
       it { is_expected.to be_grouped_into 'root' }
     end
 
-    if (fact('osfamily') == 'Debian')
+    if fact('osfamily') == 'Debian'
       describe file('/etc/init/vault.conf') do
         it { is_expected.to be_file }
         it { is_expected.to be_mode 444 }
@@ -56,14 +55,14 @@ describe 'vault class' do
         its(:content) { is_expected.to include 'env USER=vault' }
         its(:content) { is_expected.to include 'env GROUP=vault' }
         its(:content) { is_expected.to include 'exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG ' }
-        its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
+        its(:content) { is_expected.to match %r{export GOMAXPROCS=\${GOMAXPROCS:-\d+}} }
       end
       describe file('/etc/init.d/vault') do
         it { is_expected.to be_symlink }
         it { is_expected.to be_linked_to '/lib/init/upstart-job' }
       end
-    elsif (fact('osfamily') == 'RedHat')
-      if (fact('operatingsystemmajrelease') == '6')
+    elsif fact('osfamily') == 'RedHat'
+      if fact('operatingsystemmajrelease') == '6'
         describe file('/etc/init.d/vault') do
           it { is_expected.to be_file }
           it { is_expected.to be_mode 755 }
@@ -72,7 +71,7 @@ describe 'vault class' do
           its(:content) { is_expected.to include 'daemon --user vault "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"' }
           its(:content) { is_expected.to include 'conffile="/etc/vault/config.json"' }
           its(:content) { is_expected.to include 'exec="/usr/local/bin/vault"' }
-          its(:content) { is_expected.to match /export GOMAXPROCS=\${GOMAXPROCS:-\d+}/ }
+          its(:content) { is_expected.to match %r{export GOMAXPROCS=\${GOMAXPROCS:-\d+}} }
         end
       else
         describe file('/etc/systemd/system/vault.service') do
@@ -83,7 +82,7 @@ describe 'vault class' do
           its(:content) { is_expected.to include 'User=vault' }
           its(:content) { is_expected.to include 'Group=vault' }
           its(:content) { is_expected.to include 'ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json ' }
-          its(:content) { is_expected.to match /Environment=GOMAXPROCS=\d+/ }
+          its(:content) { is_expected.to match %r{Environment=GOMAXPROCS=\d+} }
         end
         describe command('systemctl list-units') do
           its(:stdout) { is_expected.to include 'vault.service' }
@@ -97,7 +96,7 @@ describe 'vault class' do
 
     describe file('/etc/vault/config.json') do
       it { is_expected.to be_file }
-      its(:content) { should include '"address":"127.0.0.1:8200"' }
+      its(:content) { is_expected.to include '"address":"127.0.0.1:8200"' }
     end
 
     describe service('vault') do

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -8,23 +8,25 @@ describe 'vault' do
   on_supported_os.each do |os, facts|
     context "on #{os} " do
       let :facts do
-        facts.merge({service_provider: 'init'})
+        facts.merge(service_provider: 'init', processorcount: 3)
       end
 
-      context "vault class with simple configuration" do
-        let(:params) {{
-          :storage => {
-            'file' => {
-              'path' => '/data/vault'
-            }
+      context 'vault class with simple configuration' do
+        let(:params) do
+          {
+            storage: {
+              'file' => {
+                'path' => '/data/vault'
+              }
             },
-          :listener => {
-            'tcp' => {
-              'address'     => '127.0.0.1:8200',
-              'tls_disable' => 1,
+            listener: {
+              'tcp' => {
+                'address'     => '127.0.0.1:8200',
+                'tls_disable' => 1
+              }
             }
           }
-        }}
+        end
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('vault') }
@@ -34,139 +36,157 @@ describe 'vault' do
         it { is_expected.to contain_class('vault::config') }
         it { is_expected.to contain_class('vault::service').that_subscribes_to('Class[vault::config]') }
 
-        it { is_expected.to contain_service('vault')
-          .with_ensure('running')
-          .with_enable(true)
+        it {
+          is_expected.to contain_service('vault').
+            with_ensure('running').
+            with_enable(true)
         }
         it { is_expected.to contain_user('vault') }
         it { is_expected.to contain_group('vault') }
         it { is_expected.not_to contain_file('/data/vault') }
 
-        context "do not manage user and group" do
-          let(:params) {{
-            :manage_user => false,
-            :manage_group => false
-          }}
+        context 'do not manage user and group' do
+          let(:params) do
+            {
+              manage_user: false,
+              manage_group: false
+            }
+          end
+
           it { is_expected.not_to contain_user('vault') }
           it { is_expected.not_to contain_group('vault') }
         end
 
         it {
-          is_expected.to contain_file('/etc/vault')
-            .with_ensure('directory')
-            .with_purge('true')
-            .with_recurse('true')
-            .with_owner('vault')
-            .with_group('vault')
+          is_expected.to contain_file('/etc/vault').
+            with_ensure('directory').
+            with_purge('true').
+            with_recurse('true').
+            with_owner('vault').
+            with_group('vault')
         }
         it {
-          is_expected.to contain_file('/etc/vault/config.json')
-            .with_owner('vault')
-            .with_group('vault')
-            .with_content(/"storage":\s*{\s*"file":\s*{\s*"path":\s*"\/data\/vault"/)
-            .with_content(/"listener":\s*{\s*"tcp":/)
-            .with_content(/"address":\s*"127.0.0.1:8200"/)
-            .with_content(/"tls_disable":\s*1/)
+          is_expected.to contain_file('/etc/vault/config.json').
+            with_owner('vault').
+            with_group('vault').
+            with_content(/"storage":\s*{\s*"file":\s*{\s*"path":\s*"\/data\/vault"/).
+            with_content(%r{"address":\s*"127.0.0.1:8200"}).
+            with_content(%r{"tls_disable":\s*1})
         }
 
         it { is_expected.to contain_file('/usr/local/bin/vault').with_mode('0755') }
         it {
-          is_expected.to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault')
-            .with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep')
-            .that_subscribes_to('File[/usr/local/bin/vault]')
+          is_expected.to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault').
+            with_unless('getcap /usr/local/bin/vault | grep cap_ipc_lock+ep').
+            that_subscribes_to('File[/usr/local/bin/vault]')
         }
 
-        context "disable mlock" do
-          let(:params) {{
-              :disable_mlock => true
-          }}
+        context 'disable mlock' do
+          let(:params) do
+            {
+              disable_mlock: true
+            }
+          end
+
           it { is_expected.not_to contain_exec('setcap cap_ipc_lock=+ep /usr/local/bin/vault') }
 
           it {
-            is_expected.to contain_file('/etc/vault/config.json')
-              .with_content(/"disable_mlock":\s*true/)
+            is_expected.to contain_file('/etc/vault/config.json').
+              with_content(%r{"disable_mlock":\s*true})
           }
         end
 
-        context "default download options" do
-          let(:params) {{ :version  => '0.7.0' }}
-          it {
-            is_expected.to contain_archive('/tmp/vault.zip')
-              .with_source('https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip')
-              .that_comes_before('File[/usr/local/bin/vault]')
-          }
-        end
-
-        context "specifying a custom download params" do
-          let(:params) {{
-            :version  => '0.6.0',
-            :download_url_base => 'http://my_site.example.com/vault/',
-            :package_name => 'vaultbinary',
-            :download_extension => 'tar.gz'
-          }}
+        context 'default download options' do
+          let(:params) { { version: '0.7.0' } }
 
           it {
-            is_expected.to contain_archive('/tmp/vault.zip')
-              .with_source('http://my_site.example.com/vault/0.6.0/vaultbinary_0.6.0_linux_amd64.tar.gz')
-              .that_comes_before('File[/usr/local/bin/vault]')
+            is_expected.to contain_archive('/tmp/vault.zip').
+              with_source('https://releases.hashicorp.com/vault/0.7.0/vault_0.7.0_linux_amd64.zip').
+              that_comes_before('File[/usr/local/bin/vault]')
           }
         end
 
-        context "installs from download url" do
-          let(:params) {{
-            :download_url   => 'http://example.com/vault.zip',
-            :install_method => 'archive',
-          }}
+        context 'specifying a custom download params' do
+          let(:params) do
+            {
+              version: '0.6.0',
+              download_url_base: 'http://my_site.example.com/vault/',
+              package_name: 'vaultbinary',
+              download_extension: 'tar.gz'
+            }
+          end
 
           it {
-            is_expected.to contain_archive('/tmp/vault.zip')
-              .with_source('http://example.com/vault.zip')
-              .that_comes_before('File[/usr/local/bin/vault]')
+            is_expected.to contain_archive('/tmp/vault.zip').
+              with_source('http://my_site.example.com/vault/0.6.0/vaultbinary_0.6.0_linux_amd64.tar.gz').
+              that_comes_before('File[/usr/local/bin/vault]')
           }
         end
 
-        context "installs from repository" do
-          let(:params) {{
-            :install_method => 'repo',
-            :package_name   => 'vault',
-            :package_ensure => 'installed',
-          }}
+        context 'installs from download url' do
+          let(:params) do
+            {
+              download_url: 'http://example.com/vault.zip',
+              install_method: 'archive'
+            }
+          end
 
-          it { should contain_package('vault') }
+          it {
+            is_expected.to contain_archive('/tmp/vault.zip').
+              with_source('http://example.com/vault.zip').
+              that_comes_before('File[/usr/local/bin/vault]')
+          }
+        end
+
+        context 'installs from repository' do
+          let(:params) do
+            {
+              install_method: 'repo',
+              package_name: 'vault',
+              package_ensure: 'installed'
+            }
+          end
+
+          it { is_expected.to contain_package('vault') }
         end
       end
 
-      context "when specifying manage_service" do
-        let(:params) {{
-          :manage_service => false,
-          :storage => {
-            'file' => {
-              'path' => '/data/vault'
+      context 'when specifying manage_service' do
+        let(:params) do
+          {
+            manage_service: false,
+            storage: {
+              'file' => {
+                'path' => '/data/vault'
+              }
             }
-            }
-        }}
+          }
+        end
 
-        it { is_expected.to_not contain_service('vault')
-          .with_ensure('running')
-          .with_enable(true)
+        it {
+          is_expected.not_to contain_service('vault').
+            with_ensure('running').
+            with_enable(true)
         }
       end
 
-      context "when specifying manage_storage_dir" do
-        let(:params) {{
-          :manage_storage_dir => true,
-          :storage => {
-            'file' => {
-              'path' => '/data/vault'
+      context 'when specifying manage_storage_dir' do
+        let(:params) do
+          {
+            manage_storage_dir: true,
+            storage: {
+              'file' => {
+                'path' => '/data/vault'
+              }
             }
-            }
-        }}
+          }
+        end
 
         it {
-          is_expected.to contain_file('/data/vault')
-            .with_ensure('directory')
-            .with_owner('vault')
-            .with_group('vault')
+          is_expected.to contain_file('/data/vault').
+            with_ensure('directory').
+            with_owner('vault').
+            with_group('vault')
         }
       end
       case facts[:os]['family']
@@ -175,97 +195,111 @@ describe 'vault' do
         when 2017
           context 'RedHat 7 Amazon Linux specific' do
             let facts do
-              facts.merge({service_provider: 'sysv'})
+              facts.merge(service_provider: 'sysv', processorcount: 3)
             end
+
             context 'includes SysV init script' do
               it {
-                is_expected.to contain_file('/etc/init.d/vault')
-                  .with_mode('0755')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_content(%r{^#!/bin/sh})
-                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-                  .with_content(%r{OPTIONS=\$OPTIONS:-""})
-                  .with_content(%r{exec="/usr/local/bin/vault"})
-                  .with_content(%r{conffile="/etc/vault/config.json"})
-                  .with_content(%r{chown vault \$logfile \$pidfile})
+                is_expected.to contain_file('/etc/init.d/vault').
+                  with_mode('0755').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_content(%r{^#!/bin/sh}).
+                  with_content(%r{export GOMAXPROCS=\${GOMAXPROCS:-3}}).
+                  with_content(%r{OPTIONS=\$OPTIONS:-""}).
+                  with_content(%r{exec="/usr/local/bin/vault"}).
+                  with_content(%r{conffile="/etc/vault/config.json"}).
+                  with_content(%r{chown vault \$logfile \$pidfile})
               }
             end
             context 'service with non-default options' do
-              let(:params) {{
-                :bin_dir => '/opt/bin',
-                :config_dir => '/opt/etc/vault',
-                :service_options => '-log-level=info',
-                :user => 'root',
-                :group => 'admin',
-                :num_procs => '5',
-              }}
+              let(:params) do
+                {
+                  bin_dir: '/opt/bin',
+                  config_dir: '/opt/etc/vault',
+                  service_options: '-log-level=info',
+                  user: 'root',
+                  group: 'admin',
+                  num_procs: '5'
+                }
+              end
+
               it {
-                is_expected.to contain_file('/etc/init.d/vault')
-                  .with_mode('0755')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_content(%r{^#!/bin/sh})
-                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
-                  .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
-                  .with_content(%r{exec="/opt/bin/vault"})
-                  .with_content(%r{conffile="/opt/etc/vault/config.json"})
-                  .with_content(%r{chown root \$logfile \$pidfile})
+                is_expected.to contain_file('/etc/init.d/vault').
+                  with_mode('0755').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_content(%r{^#!/bin/sh}).
+                  with_content(%r{export GOMAXPROCS=\${GOMAXPROCS:-5}}).
+                  with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"}).
+                  with_content(%r{exec="/opt/bin/vault"}).
+                  with_content(%r{conffile="/opt/etc/vault/config.json"}).
+                  with_content(%r{chown root \$logfile \$pidfile})
               }
             end
             context 'does not include systemd reload' do
-              it {
-                is_expected.to_not contain_exec('systemd-reload')
-              }
+              it { is_expected.not_to contain_exec('systemd-reload') }
             end
             context 'install through repo with default service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: :undef
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through repo without service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through repo with service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
 
             context 'install through archive with default service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: :undef
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
             context 'install through archive without service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through archive with service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
@@ -273,97 +307,111 @@ describe 'vault' do
         when 6
           context 'RedHat 6 specific' do
             let :facts do
-              facts.merged({service_provider: 'sysv'})
+              facts.merged(service_provider: 'sysv', processorcount: 3)
             end
+
             context 'includes SysV init script' do
               it {
-                is_expected.to contain_file('/etc/init.d/vault')
-                  .with_mode('0755')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_content(%r{^#!/bin/sh})
-                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-                  .with_content(%r{OPTIONS=\$OPTIONS:-""})
-                  .with_content(%r{exec="/usr/local/bin/vault"})
-                  .with_content(%r{conffile="/etc/vault/config.json"})
-                  .with_content(%r{chown vault \$logfile \$pidfile})
+                is_expected.to contain_file('/etc/init.d/vault').
+                  with_mode('0755').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_content(%r{^#!/bin/sh}).
+                  with_content(%r{export GOMAXPROCS=\${GOMAXPROCS:-3}}).
+                  with_content(%r{OPTIONS=\$OPTIONS:-""}).
+                  with_content(%r{exec="/usr/local/bin/vault"}).
+                  with_content(%r{conffile="/etc/vault/config.json"}).
+                  with_content(%r{chown vault \$logfile \$pidfile})
               }
             end
             context 'service with non-default options' do
-              let(:params) {{
-                :bin_dir => '/opt/bin',
-                :config_dir => '/opt/etc/vault',
-                :service_options => '-log-level=info',
-                :user => 'root',
-                :group => 'admin',
-                :num_procs => '5',
-              }}
+              let(:params) do
+                {
+                  bin_dir: '/opt/bin',
+                  config_dir: '/opt/etc/vault',
+                  service_options: '-log-level=info',
+                  user: 'root',
+                  group: 'admin',
+                  num_procs: '5'
+                }
+              end
+
               it {
-                is_expected.to contain_file('/etc/init.d/vault')
-                  .with_mode('0755')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_content(%r{^#!/bin/sh})
-                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
-                  .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
-                  .with_content(%r{exec="/opt/bin/vault"})
-                  .with_content(%r{conffile="/opt/etc/vault/config.json"})
-                  .with_content(%r{chown root \$logfile \$pidfile})
+                is_expected.to contain_file('/etc/init.d/vault').
+                  with_mode('0755').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_content(%r{^#!/bin/sh}).
+                  with_content(%r{export GOMAXPROCS=\${GOMAXPROCS:-5}}).
+                  with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"}).
+                  with_content(%r{exec="/opt/bin/vault"}).
+                  with_content(%r{conffile="/opt/etc/vault/config.json"}).
+                  with_content(%r{chown root \$logfile \$pidfile})
               }
             end
             context 'does not include systemd reload' do
-              it {
-                is_expected.to_not contain_exec('systemd-reload')
-              }
+              it { is_expected.not_to contain_exec('systemd-reload') }
             end
             context 'install through repo with default service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: :undef
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through repo without service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through repo with service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
 
             context 'install through archive with default service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: :undef
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
             context 'install through archive without service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+              it { is_expected.not_to contain_file('/etc/init.d/vault') }
             end
             context 'install through archive with service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/init.d/vault') }
             end
@@ -371,137 +419,156 @@ describe 'vault' do
         when 7
           context 'RedHat >=7 specific' do
             let :facts do
-              facts.merge({service_provider: 'systemd'})
+              facts.merge(service_provider: 'systemd', processorcount: 3)
             end
+
             context 'includes systemd init script' do
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                  .with_mode('0644')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_notify('Exec[systemd-reload]')
-                  .with_content(/^# vault systemd unit file/)
-                  .with_content(/^User=vault$/)
-                  .with_content(/^Group=vault$/)
-                  .with_content(/Environment=GOMAXPROCS=3/)
-                  .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                  .with_content(/SecureBits=keep-caps/)
-                  .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                  .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
-                  .with_content(/NoNewPrivileges=yes/)
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=vault$}).
+                  with_content(%r{^Group=vault$}).
+                  with_content(%r{Environment=GOMAXPROCS=3}).
+                  with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $}).
+                  with_content(%r{SecureBits=keep-caps}).
+                  with_content(%r{Capabilities=CAP_IPC_LOCK\+ep}).
+                  with_content(%r{CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK}).
+                  with_content(%r{NoNewPrivileges=yes})
               }
             end
             context 'service with non-default options' do
-              let(:params) {{
-                :bin_dir => '/opt/bin',
-                :config_dir => '/opt/etc/vault',
-                :service_options => '-log-level=info',
-                :user => 'root',
-                :group => 'admin',
-                :num_procs => 8,
-              }}
+              let(:params) do
+                {
+                  bin_dir: '/opt/bin',
+                  config_dir: '/opt/etc/vault',
+                  service_options: '-log-level=info',
+                  user: 'root',
+                  group: 'admin',
+                  num_procs: 8
+                }
+              end
+
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                  .with_mode('0644')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_notify('Exec[systemd-reload]')
-                  .with_content(/^# vault systemd unit file/)
-                  .with_content(/^User=root$/)
-                  .with_content(/^Group=admin$/)
-                  .with_content(/Environment=GOMAXPROCS=8/)
-                  .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=root$}).
+                  with_content(%r{^Group=admin$}).
+                  with_content(%r{Environment=GOMAXPROCS=8}).
+                  with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
               }
             end
             context 'with mlock disabled' do
-              let(:params) {{
-                :disable_mlock   => true,
-                :storage => {
-                  'file' => {
-                    'path' => '/data/vault'
-                  }
-                },
-                :listener => {
-                  'tcp' => {
-                    'address'     => '127.0.0.1:8200',
-                    'tls_disable' => 1,
+              let(:params) do
+                {
+                  disable_mlock: true,
+                  storage: {
+                    'file' => {
+                      'path' => '/data/vault'
+                    }
+                  },
+                  listener: {
+                    'tcp' => {
+                      'address'     => '127.0.0.1:8200',
+                      'tls_disable' => 1
+                    }
                   }
                 }
-              }}
+              end
+
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                  .with_mode('0644')
-                  .with_ensure('file')
-                  .with_owner('root')
-                  .with_group('root')
-                  .with_notify('Exec[systemd-reload]')
-                  .with_content(/^# vault systemd unit file/)
-                  .with_content(/^User=vault$/)
-                  .with_content(/^Group=vault$/)
-                  .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                  .without_content(/SecureBits=keep-caps/)
-                  .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                  .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
-                  .with_content(/NoNewPrivileges=yes/)
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=vault$}).
+                  with_content(%r{^Group=vault$}).
+                  with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $}).
+                  without_content(%r{SecureBits=keep-caps}).
+                  without_content(%r{Capabilities=CAP_IPC_LOCK\+ep}).
+                  with_content(%r{CapabilityBoundingSet=CAP_SYSLOG}).
+                  with_content(%r{NoNewPrivileges=yes})
               }
             end
             context 'includes systemd reload' do
               it {
-                is_expected.to contain_exec('systemd-reload')
-                  .with_command('systemctl daemon-reload')
-                  .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
-                  .with_user('root')
-                  .with_refreshonly(true)
+                is_expected.to contain_exec('systemd-reload').
+                  with_command('systemctl daemon-reload').
+                  with_path('/bin:/usr/bin:/sbin:/usr/sbin').
+                  with_user('root').
+                  with_refreshonly(true)
               }
             end
             context 'install through repo with default service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: :undef
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through repo without service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through repo with service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end
 
             context 'install through archive with default service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: :undef
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through archive without service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through archive with service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end
@@ -509,245 +576,280 @@ describe 'vault' do
         end
       when 'Debian'
         context 'on Debian OS family' do
-          context 'includes init link to upstart-job' do
-            it {
-              is_expected.to contain_file('/etc/init.d/vault')
-                              .with_ensure('link')
-                              .with_target('/lib/init/upstart-job')
-                              .with_mode('0755')
-            }
+          context 'with upstart' do
+            let :facts do
+              facts.merge(service_provider: 'upstart', processorcount: 3)
+            end
+
+            context 'includes init link to upstart-job' do
+              it {
+                is_expected.to contain_file('/etc/init.d/vault').
+                  with_ensure('link').
+                  with_target('/lib/init/upstart-job').
+                  with_mode('0755')
+              }
+            end
+            context 'contains /etc/init/vault.conf' do
+              it {
+                is_expected.to contain_file('/etc/init/vault.conf').
+                  with_mode('0444').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_content(%r{^# vault Agent \(Upstart unit\)}).
+                  with_content(%r{env USER=vault}).
+                  with_content(%r{env GROUP=vault}).
+                  with_content(/env CONFIG=\/etc\/vault\/config.json/).
+                  with_content(/env VAULT=\/usr\/local\/bin\/vault/).
+                  with_content(%r{exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $}).
+                  with_content(%r{export GOMAXPROCS=\${GOMAXPROCS:-3}})
+              }
+            end
           end
-          context 'contains /etc/init/vault.conf' do
+          context 'service with modified options and sysv init' do
+            let :facts do
+              facts.merge(service_provider: 'init')
+            end
+            let(:params) do
+              {
+                bin_dir: '/opt/bin',
+                config_dir: '/opt/etc/vault',
+                service_options: '-log-level=info',
+                user: 'root',
+                group: 'admin'
+              }
+            end
+
             it {
-              is_expected.to contain_file('/etc/init/vault.conf')
-                              .with_mode('0444')
-                              .with_ensure('file')
-                              .with_owner('root')
-                              .with_group('root')
-                              .with_content(/^# vault Agent \(Upstart unit\)/)
-                              .with_content(/env USER=vault/)
-                              .with_content(/env GROUP=vault/)
-                              .with_content(/env CONFIG=\/etc\/vault\/config.json/)
-                              .with_content(/env VAULT=\/usr\/local\/bin\/vault/)
-                              .with_content(/exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $/)
-                              .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-            }
-          end
-          context "service with modified options" do
-            let(:params) {{
-                            :bin_dir => '/opt/bin',
-                            :config_dir => '/opt/etc/vault',
-                            :service_options => '-log-level=info',
-                            :user => 'root',
-                            :group => 'admin',
-                          }}
-            it {
-              is_expected.to contain_file('/etc/init/vault.conf')
-                              .with_content(/env USER=root/)
-                              .with_content(/env GROUP=admin/)
-                              .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
-                              .with_content(/env VAULT=\/opt\/bin\/vault/)
-                              .with_content(/start-stop-daemon .* -log-level=info$/)
-            }
-            it {
-              is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
-                              .with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
-                              .that_subscribes_to('File[/opt/bin/vault]')
+              is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault').
+                with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep').
+                that_subscribes_to('File[/opt/bin/vault]')
             }
             it { is_expected.to contain_file('/opt/etc/vault/config.json') }
 
             it { is_expected.to contain_file('/opt/bin/vault').with_mode('0755') }
             it {
-              is_expected.to contain_file('/opt/etc/vault')
-                              .with_ensure('directory')
-                              .with_purge('true') \
-                              .with_recurse('true')
+              is_expected.to contain_file('/opt/etc/vault').
+                with_ensure('directory').
+                with_purge('true'). \
+                with_recurse('true')
             }
             it { is_expected.to contain_user('root') }
             it { is_expected.to contain_group('admin') }
           end
           context 'install through repo with default service management' do
-            let(:params) {{
-                :install_method      => 'repo',
-                :manage_service_file => :undef,
-            }}
+            let(:params) do
+              {
+                install_method: 'repo',
+                manage_service_file: :undef
+              }
+            end
 
-            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            it { is_expected.not_to contain_file('/etc/init.d/vault') }
           end
           context 'install through repo without service management' do
-            let(:params) {{
-                :install_method      => 'repo',
-                :manage_service_file => false,
-            }}
+            let(:params) do
+              {
+                install_method: 'repo',
+                manage_service_file: false
+              }
+            end
 
-            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            it { is_expected.not_to contain_file('/etc/init.d/vault') }
           end
           context 'install through repo with service management' do
-            let(:params) {{
-                :install_method      => 'repo',
-                :manage_service_file => true,
-            }}
+            let(:params) do
+              {
+                install_method: 'repo',
+                manage_service_file: true
+              }
+            end
 
             it { is_expected.to contain_file('/etc/init.d/vault') }
           end
 
           context 'install through archive with default service management' do
-            let(:params) {{
-                :install_method      => 'archive',
-                :manage_service_file => :undef,
-            }}
+            let(:params) do
+              {
+                install_method: 'archive',
+                manage_service_file: :undef
+              }
+            end
 
             it { is_expected.to contain_file('/etc/init.d/vault') }
           end
           context 'install through archive without service management' do
-            let(:params) {{
-                :install_method      => 'archive',
-                :manage_service_file => false,
-            }}
+            let(:params) do
+              {
+                install_method: 'archive',
+                manage_service_file: false
+              }
+            end
 
-            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            it { is_expected.not_to contain_file('/etc/init.d/vault') }
           end
           context 'install through archive with service management' do
-            let(:params) {{
-                :install_method      => 'archive',
-                :manage_service_file => true,
-            }}
+            let(:params) do
+              {
+                install_method: 'archive',
+                manage_service_file: true
+              }
+            end
 
             it { is_expected.to contain_file('/etc/init.d/vault') }
           end
           context 'on Debian based with systemd' do
             let :facts do
-              facts.merge({service_provider: 'systemd'})
+              facts.merge(service_provider: 'systemd', processorcount: 3)
             end
+
             context 'includes systemd init script' do
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                                .with_mode('0644')
-                                .with_ensure('file')
-                                .with_owner('root')
-                                .with_group('root')
-                                .with_notify('Exec[systemd-reload]')
-                                .with_content(/^# vault systemd unit file/)
-                                .with_content(/^User=vault$/)
-                                .with_content(/^Group=vault$/)
-                                .with_content(/Environment=GOMAXPROCS=3/)
-                                .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                                .with_content(/SecureBits=keep-caps/)
-                                .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                                .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
-                                .with_content(/NoNewPrivileges=yes/)
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=vault$}).
+                  with_content(%r{^Group=vault$}).
+                  with_content(%r{Environment=GOMAXPROCS=3}).
+                  with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $}).
+                  with_content(%r{SecureBits=keep-caps}).
+                  with_content(%r{Capabilities=CAP_IPC_LOCK\+ep}).
+                  with_content(%r{CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK}).
+                  with_content(%r{NoNewPrivileges=yes})
               }
             end
             context 'service with non-default options' do
-              let(:params) {{
-                              :bin_dir => '/opt/bin',
-                              :config_dir => '/opt/etc/vault',
-                              :service_options => '-log-level=info',
-                              :user => 'root',
-                              :group => 'admin',
-                              :num_procs => 8,
-                            }}
+              let(:params) do
+                {
+                  bin_dir: '/opt/bin',
+                  config_dir: '/opt/etc/vault',
+                  service_options: '-log-level=info',
+                  user: 'root',
+                  group: 'admin',
+                  num_procs: 8
+                }
+              end
+
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                                .with_mode('0644')
-                                .with_ensure('file')
-                                .with_owner('root')
-                                .with_group('root')
-                                .with_notify('Exec[systemd-reload]')
-                                .with_content(/^# vault systemd unit file/)
-                                .with_content(/^User=root$/)
-                                .with_content(/^Group=admin$/)
-                                .with_content(/Environment=GOMAXPROCS=8/)
-                                .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=root$}).
+                  with_content(%r{^Group=admin$}).
+                  with_content(%r{Environment=GOMAXPROCS=8}).
+                  with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
               }
             end
             context 'with mlock disabled' do
-              let(:params) {{
-                              :disable_mlock   => true,
-                              :storage => {
-                                'file' => {
-                                  'path' => '/data/vault'
-                                }
-                              },
-                              :listener => {
-                                'tcp' => {
-                                  'address'     => '127.0.0.1:8200',
-                                  'tls_disable' => 1,
-                                }
-                              }
-                            }}
+              let(:params) do
+                {
+                  disable_mlock: true,
+                  storage: {
+                    'file' => {
+                      'path' => '/data/vault'
+                    }
+                  },
+                  listener: {
+                    'tcp' => {
+                      'address'     => '127.0.0.1:8200',
+                      'tls_disable' => 1
+                    }
+                  }
+                }
+              end
+
               it {
-                is_expected.to contain_file('/etc/systemd/system/vault.service')
-                                .with_mode('0644')
-                                .with_ensure('file')
-                                .with_owner('root')
-                                .with_group('root')
-                                .with_notify('Exec[systemd-reload]')
-                                .with_content(/^# vault systemd unit file/)
-                                .with_content(/^User=vault$/)
-                                .with_content(/^Group=vault$/)
-                                .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                                .without_content(/SecureBits=keep-caps/)
-                                .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                                .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
-                                .with_content(/NoNewPrivileges=yes/)
+                is_expected.to contain_file('/etc/systemd/system/vault.service').
+                  with_mode('0644').
+                  with_ensure('file').
+                  with_owner('root').
+                  with_group('root').
+                  with_notify('Exec[systemd-reload]').
+                  with_content(%r{^# vault systemd unit file}).
+                  with_content(%r{^User=vault$}).
+                  with_content(%r{^Group=vault$}).
+                  with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $}).
+                  without_content(%r{SecureBits=keep-caps}).
+                  without_content(%r{Capabilities=CAP_IPC_LOCK\+ep}).
+                  with_content(%r{CapabilityBoundingSet=CAP_SYSLOG}).
+                  with_content(%r{NoNewPrivileges=yes})
               }
             end
             context 'includes systemd reload' do
               it {
-                is_expected.to contain_exec('systemd-reload')
-                                .with_command('systemctl daemon-reload')
-                                .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
-                                .with_user('root')
-                                .with_refreshonly(true)
+                is_expected.to contain_exec('systemd-reload').
+                  with_command('systemctl daemon-reload').
+                  with_path('/bin:/usr/bin:/sbin:/usr/sbin').
+                  with_user('root').
+                  with_refreshonly(true)
               }
             end
             context 'install through repo with default service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: :undef
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through repo without service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through repo with service management' do
-              let(:params) {{
-                  :install_method      => 'repo',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'repo',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end
 
             context 'install through archive with default service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => :undef,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: :undef
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through archive without service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => false,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: false
+                }
+              end
 
-              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+              it { is_expected.not_to contain_file('/etc/systemd/system/vault.service') }
             end
             context 'install through archive with service management' do
-              let(:params) {{
-                  :install_method      => 'archive',
-                  :manage_service_file => true,
-              }}
+              let(:params) do
+                {
+                  install_method: 'archive',
+                  manage_service_file: true
+                }
+              end
 
               it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
             end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper'
 
 describe 'vault' do
-  ['RedHat','Debian'].each do |osfamily|
-    context "on #{osfamily}" do
-      let(:facts) {{
-        :path           => '/usr/local/bin:/usr/bin:/bin',
-        :osfamily       => "#{osfamily}",
-        :processorcount => '3',
-        :architecture   => 'x86_64',
-        :kernel         => 'Linux',
-        :service_provider => 'systemd',
-      }}
+  let :node do
+    'agent.example.com'
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts.merge({service_provider: 'init'})
+      end
 
       context "vault class with simple configuration" do
         let(:params) {{
@@ -170,645 +169,591 @@ describe 'vault' do
             .with_group('vault')
         }
       end
-    end
-  end
-  context 'RedHat 7 Amazon Linux specific' do
-   let(:facts) {{
-      :path                      => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily                  => 'RedHat',
-      :operatingsystem           => 'Amazon',
-      :operatingsystemmajrelease => '7',
-      :processorcount            => '3',
-      :architecture              => 'x86_64',
-      :kernel                    => 'Linux',
-      :service_provider          => 'sysv',
-   }}
-   context 'includes SysV init script' do
-      it {
-        is_expected.to contain_file('/etc/init.d/vault')
-          .with_mode('0755')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-          .with_content(%r{daemon --user vault "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
-          .with_content(%r{OPTIONS=\$OPTIONS:-""})
-          .with_content(%r{exec="/usr/local/bin/vault"})
-          .with_content(%r{conffile="/etc/vault/config.json"})
-          .with_content(%r{chown vault \$logfile \$pidfile})
-      }
-    end
-    context 'service with non-default options' do
-      let(:params) {{
-        :bin_dir => '/opt/bin',
-        :config_dir => '/opt/etc/vault',
-        :service_options => '-log-level=info',
-        :user => 'root',
-        :group => 'admin',
-        :num_procs => '5',
-      }}
-      it {
-        is_expected.to contain_file('/etc/init.d/vault')
-          .with_mode('0755')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
-          .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
-          .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
-          .with_content(%r{exec="/opt/bin/vault"})
-          .with_content(%r{conffile="/opt/etc/vault/config.json"})
-          .with_content(%r{chown root \$logfile \$pidfile})
-      }
-    end
-    context 'does not include systemd reload' do
-      it {
-        is_expected.to_not contain_exec('systemd-reload')
-      }
-    end
-    context 'install through repo with default service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => :undef,
-      }}
+      case facts[:os]['family']
+      when 'RedHat'
+        case facts[:os]['release']['major'].to_i
+        when 2017
+          context 'RedHat 7 Amazon Linux specific' do
+            let facts do
+              facts.merge({service_provider: 'sysv'})
+            end
+            context 'includes SysV init script' do
+              it {
+                is_expected.to contain_file('/etc/init.d/vault')
+                  .with_mode('0755')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_content(%r{^#!/bin/sh})
+                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
+                  .with_content(%r{OPTIONS=\$OPTIONS:-""})
+                  .with_content(%r{exec="/usr/local/bin/vault"})
+                  .with_content(%r{conffile="/etc/vault/config.json"})
+                  .with_content(%r{chown vault \$logfile \$pidfile})
+              }
+            end
+            context 'service with non-default options' do
+              let(:params) {{
+                :bin_dir => '/opt/bin',
+                :config_dir => '/opt/etc/vault',
+                :service_options => '-log-level=info',
+                :user => 'root',
+                :group => 'admin',
+                :num_procs => '5',
+              }}
+              it {
+                is_expected.to contain_file('/etc/init.d/vault')
+                  .with_mode('0755')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_content(%r{^#!/bin/sh})
+                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
+                  .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
+                  .with_content(%r{exec="/opt/bin/vault"})
+                  .with_content(%r{conffile="/opt/etc/vault/config.json"})
+                  .with_content(%r{chown root \$logfile \$pidfile})
+              }
+            end
+            context 'does not include systemd reload' do
+              it {
+                is_expected.to_not contain_exec('systemd-reload')
+              }
+            end
+            context 'install through repo with default service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => :undef,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through repo without service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through repo without service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through repo with service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through repo with service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
 
-    context 'install through archive with default service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => :undef,
-      }}
+            context 'install through archive with default service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => :undef,
+              }}
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
-    context 'install through archive without service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
+            context 'install through archive without service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through archive with service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through archive with service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
+          end
+        when 6
+          context 'RedHat 6 specific' do
+            let :facts do
+              facts.merged({service_provider: 'sysv'})
+            end
+            context 'includes SysV init script' do
+              it {
+                is_expected.to contain_file('/etc/init.d/vault')
+                  .with_mode('0755')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_content(%r{^#!/bin/sh})
+                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
+                  .with_content(%r{OPTIONS=\$OPTIONS:-""})
+                  .with_content(%r{exec="/usr/local/bin/vault"})
+                  .with_content(%r{conffile="/etc/vault/config.json"})
+                  .with_content(%r{chown vault \$logfile \$pidfile})
+              }
+            end
+            context 'service with non-default options' do
+              let(:params) {{
+                :bin_dir => '/opt/bin',
+                :config_dir => '/opt/etc/vault',
+                :service_options => '-log-level=info',
+                :user => 'root',
+                :group => 'admin',
+                :num_procs => '5',
+              }}
+              it {
+                is_expected.to contain_file('/etc/init.d/vault')
+                  .with_mode('0755')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_content(%r{^#!/bin/sh})
+                  .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
+                  .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
+                  .with_content(%r{exec="/opt/bin/vault"})
+                  .with_content(%r{conffile="/opt/etc/vault/config.json"})
+                  .with_content(%r{chown root \$logfile \$pidfile})
+              }
+            end
+            context 'does not include systemd reload' do
+              it {
+                is_expected.to_not contain_exec('systemd-reload')
+              }
+            end
+            context 'install through repo with default service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => :undef,
+              }}
 
-  end
-  context 'RedHat 6 specific' do
-    let(:facts) {{
-      :path                      => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :processorcount            => '3',
-      :architecture              => 'x86_64',
-      :kernel                    => 'Linux',
-      :service_provider          => 'sysv',
-    }}
-    context 'includes SysV init script' do
-      it {
-        is_expected.to contain_file('/etc/init.d/vault')
-          .with_mode('0755')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-          .with_content(%r{daemon --user vault "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
-          .with_content(%r{OPTIONS=\$OPTIONS:-""})
-          .with_content(%r{exec="/usr/local/bin/vault"})
-          .with_content(%r{conffile="/etc/vault/config.json"})
-          .with_content(%r{chown vault \$logfile \$pidfile})
-      }
-    end
-    context 'service with non-default options' do
-      let(:params) {{
-        :bin_dir => '/opt/bin',
-        :config_dir => '/opt/etc/vault',
-        :service_options => '-log-level=info',
-        :user => 'root',
-        :group => 'admin',
-        :num_procs => '5',
-      }}
-      it {
-        is_expected.to contain_file('/etc/init.d/vault')
-          .with_mode('0755')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_content(%r{^#!/bin/sh})
-          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-5}/)
-          .with_content(%r{daemon --user root "{ \$exec server -config=\$conffile \$OPTIONS &>> \$logfile & }; echo \\\$\! >\| \$pidfile"})
-          .with_content(%r{OPTIONS=\$OPTIONS:-"-log-level=info"})
-          .with_content(%r{exec="/opt/bin/vault"})
-          .with_content(%r{conffile="/opt/etc/vault/config.json"})
-          .with_content(%r{chown root \$logfile \$pidfile})
-      }
-    end
-    context 'does not include systemd reload' do
-      it {
-        is_expected.to_not contain_exec('systemd-reload')
-      }
-    end
-    context 'install through repo with default service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => :undef,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through repo without service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through repo without service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through repo with service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through repo with service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
+            context 'install through archive with default service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => :undef,
+              }}
 
-    context 'install through archive with default service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => :undef,
-      }}
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
+            context 'install through archive without service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
-    context 'install through archive without service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to_not contain_file('/etc/init.d/vault') }
+            end
+            context 'install through archive with service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/init.d/vault') }
-    end
-    context 'install through archive with service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to contain_file('/etc/init.d/vault') }
+            end
+          end
+        when 7
+          context 'RedHat >=7 specific' do
+            let :facts do
+              facts.merge({service_provider: 'systemd'})
+            end
+            context 'includes systemd init script' do
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .with_mode('0644')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_notify('Exec[systemd-reload]')
+                  .with_content(/^# vault systemd unit file/)
+                  .with_content(/^User=vault$/)
+                  .with_content(/^Group=vault$/)
+                  .with_content(/Environment=GOMAXPROCS=3/)
+                  .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+                  .with_content(/SecureBits=keep-caps/)
+                  .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+                  .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+                  .with_content(/NoNewPrivileges=yes/)
+              }
+            end
+            context 'service with non-default options' do
+              let(:params) {{
+                :bin_dir => '/opt/bin',
+                :config_dir => '/opt/etc/vault',
+                :service_options => '-log-level=info',
+                :user => 'root',
+                :group => 'admin',
+                :num_procs => 8,
+              }}
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .with_mode('0644')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_notify('Exec[systemd-reload]')
+                  .with_content(/^# vault systemd unit file/)
+                  .with_content(/^User=root$/)
+                  .with_content(/^Group=admin$/)
+                  .with_content(/Environment=GOMAXPROCS=8/)
+                  .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+              }
+            end
+            context 'with mlock disabled' do
+              let(:params) {{
+                :disable_mlock   => true,
+                :storage => {
+                  'file' => {
+                    'path' => '/data/vault'
+                  }
+                },
+                :listener => {
+                  'tcp' => {
+                    'address'     => '127.0.0.1:8200',
+                    'tls_disable' => 1,
+                  }
+                }
+              }}
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .with_mode('0644')
+                  .with_ensure('file')
+                  .with_owner('root')
+                  .with_group('root')
+                  .with_notify('Exec[systemd-reload]')
+                  .with_content(/^# vault systemd unit file/)
+                  .with_content(/^User=vault$/)
+                  .with_content(/^Group=vault$/)
+                  .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+                  .without_content(/SecureBits=keep-caps/)
+                  .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+                  .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
+                  .with_content(/NoNewPrivileges=yes/)
+              }
+            end
+            context 'includes systemd reload' do
+              it {
+                is_expected.to contain_exec('systemd-reload')
+                  .with_command('systemctl daemon-reload')
+                  .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
+                  .with_user('root')
+                  .with_refreshonly(true)
+              }
+            end
+            context 'install through repo with default service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => :undef,
+              }}
 
-      it { is_expected.to contain_file('/etc/init.d/vault') }
-    end
-  end
-  context 'RedHat >=7 specific' do
-    let(:facts) {{
-      :path                      => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '7',
-      :processorcount            => '3',
-      :architecture              => 'x86_64',
-      :kernel                    => 'Linux',
-      :service_provider          => 'systemd',
-    }}
-    context 'includes systemd init script' do
-      it {
-        is_expected.to contain_file('/etc/systemd/system/vault.service')
-          .with_mode('0644')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_notify('Exec[systemd-reload]')
-          .with_content(/^# vault systemd unit file/)
-          .with_content(/^User=vault$/)
-          .with_content(/^Group=vault$/)
-          .with_content(/Environment=GOMAXPROCS=3/)
-          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-          .with_content(/SecureBits=keep-caps/)
-          .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
-          .with_content(/NoNewPrivileges=yes/)
-      }
-    end
-    context 'service with non-default options' do
-      let(:params) {{
-        :bin_dir => '/opt/bin',
-        :config_dir => '/opt/etc/vault',
-        :service_options => '-log-level=info',
-        :user => 'root',
-        :group => 'admin',
-        :num_procs => 8,
-      }}
-      it {
-        is_expected.to contain_file('/etc/systemd/system/vault.service')
-          .with_mode('0644')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_notify('Exec[systemd-reload]')
-          .with_content(/^# vault systemd unit file/)
-          .with_content(/^User=root$/)
-          .with_content(/^Group=admin$/)
-          .with_content(/Environment=GOMAXPROCS=8/)
-          .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
-      }
-    end
-    context 'with mlock disabled' do
-      let(:params) {{
-        :disable_mlock   => true,
-        :storage => {
-          'file' => {
-            'path' => '/data/vault'
-          }
-        },
-        :listener => {
-          'tcp' => {
-            'address'     => '127.0.0.1:8200',
-            'tls_disable' => 1,
-          }
-        }
-      }}
-      it {
-        is_expected.to contain_file('/etc/systemd/system/vault.service')
-          .with_mode('0644')
-          .with_ensure('file')
-          .with_owner('root')
-          .with_group('root')
-          .with_notify('Exec[systemd-reload]')
-          .with_content(/^# vault systemd unit file/)
-          .with_content(/^User=vault$/)
-          .with_content(/^Group=vault$/)
-          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-          .without_content(/SecureBits=keep-caps/)
-          .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-          .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
-          .with_content(/NoNewPrivileges=yes/)
-      }
-    end
-    context 'includes systemd reload' do
-      it {
-        is_expected.to contain_exec('systemd-reload')
-          .with_command('systemctl daemon-reload')
-          .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
-          .with_user('root')
-          .with_refreshonly(true)
-      }
-    end
-    context 'install through repo with default service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => :undef,
-      }}
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through repo without service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-    end
-    context 'install through repo without service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through repo with service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-    end
-    context 'install through repo with service management' do
-      let(:params) {{
-          :install_method      => 'repo',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
 
-      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-    end
+            context 'install through archive with default service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => :undef,
+              }}
 
-    context 'install through archive with default service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => :undef,
-      }}
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through archive without service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => false,
+              }}
 
-      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-    end
-    context 'install through archive without service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => false,
-      }}
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through archive with service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => true,
+              }}
 
-      it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-    end
-    context 'install through archive with service management' do
-      let(:params) {{
-          :install_method      => 'archive',
-          :manage_service_file => true,
-      }}
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
+          end
+        end
+      when 'Debian'
+        context 'on Debian OS family' do
+          context 'includes init link to upstart-job' do
+            it {
+              is_expected.to contain_file('/etc/init.d/vault')
+                              .with_ensure('link')
+                              .with_target('/lib/init/upstart-job')
+                              .with_mode('0755')
+            }
+          end
+          context 'contains /etc/init/vault.conf' do
+            it {
+              is_expected.to contain_file('/etc/init/vault.conf')
+                              .with_mode('0444')
+                              .with_ensure('file')
+                              .with_owner('root')
+                              .with_group('root')
+                              .with_content(/^# vault Agent \(Upstart unit\)/)
+                              .with_content(/env USER=vault/)
+                              .with_content(/env GROUP=vault/)
+                              .with_content(/env CONFIG=\/etc\/vault\/config.json/)
+                              .with_content(/env VAULT=\/usr\/local\/bin\/vault/)
+                              .with_content(/exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $/)
+                              .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
+            }
+          end
+          context "service with modified options" do
+            let(:params) {{
+                            :bin_dir => '/opt/bin',
+                            :config_dir => '/opt/etc/vault',
+                            :service_options => '-log-level=info',
+                            :user => 'root',
+                            :group => 'admin',
+                          }}
+            it {
+              is_expected.to contain_file('/etc/init/vault.conf')
+                              .with_content(/env USER=root/)
+                              .with_content(/env GROUP=admin/)
+                              .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
+                              .with_content(/env VAULT=\/opt\/bin\/vault/)
+                              .with_content(/start-stop-daemon .* -log-level=info$/)
+            }
+            it {
+              is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
+                              .with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
+                              .that_subscribes_to('File[/opt/bin/vault]')
+            }
+            it { is_expected.to contain_file('/opt/etc/vault/config.json') }
 
-      it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-    end
-  end
-  ['trusty','vivid'].each do |lsbdistcodename|
-    context "Ubuntu-#{lsbdistcodename}-specific" do
-      let(:facts) {{
-                     :path            => '/usr/local/bin:/usr/bin:/bin',
-                     :osfamily        => 'Debian',
-                     :lsbdistcodename => "#{lsbdistcodename}",
-                     :processorcount  => '3',
-                     :architecture    => 'x86_64',
-                     :kernel          => 'Linux',
-                     :service_provider => 'upstart',
-                   }}
-      context 'includes init link to upstart-job' do
-        it {
-          is_expected.to contain_file('/etc/init.d/vault')
-                          .with_ensure('link')
-                          .with_target('/lib/init/upstart-job')
-                          .with_mode('0755')
-        }
+            it { is_expected.to contain_file('/opt/bin/vault').with_mode('0755') }
+            it {
+              is_expected.to contain_file('/opt/etc/vault')
+                              .with_ensure('directory')
+                              .with_purge('true') \
+                              .with_recurse('true')
+            }
+            it { is_expected.to contain_user('root') }
+            it { is_expected.to contain_group('admin') }
+          end
+          context 'install through repo with default service management' do
+            let(:params) {{
+                :install_method      => 'repo',
+                :manage_service_file => :undef,
+            }}
+
+            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+          end
+          context 'install through repo without service management' do
+            let(:params) {{
+                :install_method      => 'repo',
+                :manage_service_file => false,
+            }}
+
+            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+          end
+          context 'install through repo with service management' do
+            let(:params) {{
+                :install_method      => 'repo',
+                :manage_service_file => true,
+            }}
+
+            it { is_expected.to contain_file('/etc/init.d/vault') }
+          end
+
+          context 'install through archive with default service management' do
+            let(:params) {{
+                :install_method      => 'archive',
+                :manage_service_file => :undef,
+            }}
+
+            it { is_expected.to contain_file('/etc/init.d/vault') }
+          end
+          context 'install through archive without service management' do
+            let(:params) {{
+                :install_method      => 'archive',
+                :manage_service_file => false,
+            }}
+
+            it { is_expected.to_not contain_file('/etc/init.d/vault') }
+          end
+          context 'install through archive with service management' do
+            let(:params) {{
+                :install_method      => 'archive',
+                :manage_service_file => true,
+            }}
+
+            it { is_expected.to contain_file('/etc/init.d/vault') }
+          end
+          context 'on Debian based with systemd' do
+            let :facts do
+              facts.merge({service_provider: 'systemd'})
+            end
+            context 'includes systemd init script' do
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                                .with_mode('0644')
+                                .with_ensure('file')
+                                .with_owner('root')
+                                .with_group('root')
+                                .with_notify('Exec[systemd-reload]')
+                                .with_content(/^# vault systemd unit file/)
+                                .with_content(/^User=vault$/)
+                                .with_content(/^Group=vault$/)
+                                .with_content(/Environment=GOMAXPROCS=3/)
+                                .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+                                .with_content(/SecureBits=keep-caps/)
+                                .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+                                .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
+                                .with_content(/NoNewPrivileges=yes/)
+              }
+            end
+            context 'service with non-default options' do
+              let(:params) {{
+                              :bin_dir => '/opt/bin',
+                              :config_dir => '/opt/etc/vault',
+                              :service_options => '-log-level=info',
+                              :user => 'root',
+                              :group => 'admin',
+                              :num_procs => 8,
+                            }}
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                                .with_mode('0644')
+                                .with_ensure('file')
+                                .with_owner('root')
+                                .with_group('root')
+                                .with_notify('Exec[systemd-reload]')
+                                .with_content(/^# vault systemd unit file/)
+                                .with_content(/^User=root$/)
+                                .with_content(/^Group=admin$/)
+                                .with_content(/Environment=GOMAXPROCS=8/)
+                                .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+              }
+            end
+            context 'with mlock disabled' do
+              let(:params) {{
+                              :disable_mlock   => true,
+                              :storage => {
+                                'file' => {
+                                  'path' => '/data/vault'
+                                }
+                              },
+                              :listener => {
+                                'tcp' => {
+                                  'address'     => '127.0.0.1:8200',
+                                  'tls_disable' => 1,
+                                }
+                              }
+                            }}
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                                .with_mode('0644')
+                                .with_ensure('file')
+                                .with_owner('root')
+                                .with_group('root')
+                                .with_notify('Exec[systemd-reload]')
+                                .with_content(/^# vault systemd unit file/)
+                                .with_content(/^User=vault$/)
+                                .with_content(/^Group=vault$/)
+                                .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
+                                .without_content(/SecureBits=keep-caps/)
+                                .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
+                                .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
+                                .with_content(/NoNewPrivileges=yes/)
+              }
+            end
+            context 'includes systemd reload' do
+              it {
+                is_expected.to contain_exec('systemd-reload')
+                                .with_command('systemctl daemon-reload')
+                                .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
+                                .with_user('root')
+                                .with_refreshonly(true)
+              }
+            end
+            context 'install through repo with default service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => :undef,
+              }}
+
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through repo without service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => false,
+              }}
+
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through repo with service management' do
+              let(:params) {{
+                  :install_method      => 'repo',
+                  :manage_service_file => true,
+              }}
+
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
+
+            context 'install through archive with default service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => :undef,
+              }}
+
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through archive without service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => false,
+              }}
+
+              it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
+            end
+            context 'install through archive with service management' do
+              let(:params) {{
+                  :install_method      => 'archive',
+                  :manage_service_file => true,
+              }}
+
+              it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
+            end
+          end
+        end
       end
-      context 'contains /etc/init/vault.conf' do
-        it {
-          is_expected.to contain_file('/etc/init/vault.conf')
-                          .with_mode('0444')
-                          .with_ensure('file')
-                          .with_owner('root')
-                          .with_group('root')
-                          .with_content(/^# vault Agent \(Upstart unit\)/)
-                          .with_content(/env USER=vault/)
-                          .with_content(/env GROUP=vault/)
-                          .with_content(/env CONFIG=\/etc\/vault\/config.json/)
-                          .with_content(/env VAULT=\/usr\/local\/bin\/vault/)
-                          .with_content(/exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- server -config=\$CONFIG $/)
-                          .with_content(/export GOMAXPROCS=\${GOMAXPROCS:-3}/)
-        }
-      end
-      context "service with modified options" do
-        let(:params) {{
-                        :bin_dir => '/opt/bin',
-                        :config_dir => '/opt/etc/vault',
-                        :service_options => '-log-level=info',
-                        :user => 'root',
-                        :group => 'admin',
-                      }}
-        it {
-          is_expected.to contain_file('/etc/init/vault.conf')
-                          .with_content(/env USER=root/)
-                          .with_content(/env GROUP=admin/)
-                          .with_content(/env CONFIG=\/opt\/etc\/vault\/config.json/)
-                          .with_content(/env VAULT=\/opt\/bin\/vault/)
-                          .with_content(/start-stop-daemon .* -log-level=info$/)
-        }
-        it {
-          is_expected.to contain_exec('setcap cap_ipc_lock=+ep /opt/bin/vault')
-                          .with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
-                          .that_subscribes_to('File[/opt/bin/vault]')
-        }
-        it { is_expected.to contain_file('/opt/etc/vault/config.json') }
-
-        it { is_expected.to contain_file('/opt/bin/vault').with_mode('0755') }
-        it {
-          is_expected.to contain_file('/opt/etc/vault')
-                          .with_ensure('directory')
-                          .with_purge('true') \
-                          .with_recurse('true')
-        }
-        it { is_expected.to contain_user('root') }
-        it { is_expected.to contain_group('admin') }
-      end
-      context 'install through repo with default service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => :undef,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/init.d/vault') }
-      end
-      context 'install through repo without service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => false,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/init.d/vault') }
-      end
-      context 'install through repo with service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => true,
-        }}
-
-        it { is_expected.to contain_file('/etc/init.d/vault') }
-      end
-
-      context 'install through archive with default service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => :undef,
-        }}
-
-        it { is_expected.to contain_file('/etc/init.d/vault') }
-      end
-      context 'install through archive without service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => false,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/init.d/vault') }
-      end
-      context 'install through archive with service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => true,
-        }}
-
-        it { is_expected.to contain_file('/etc/init.d/vault') }
-      end
-    end
-  end
-  ['jessie','stretch','sid','xenial','yakketi', 'zesty'].each do |lsbdistcodename|
-    context "Debian/Ubuntu #{lsbdistcodename} specific (systemd)" do
-      let(:facts) {{
-                     :path            => '/usr/local/bin:/usr/bin:/bin',
-                     :osfamily        => 'Debian',
-                     :lsbdistcodename => "#{lsbdistcodename}",
-                     :processorcount  => '3',
-                     :architecture    => 'x86_64',
-                     :kernel          => 'Linux',
-                     :service_provider => 'systemd',
-                   }}
-      context 'includes systemd init script' do
-        it {
-          is_expected.to contain_file('/etc/systemd/system/vault.service')
-                          .with_mode('0644')
-                          .with_ensure('file')
-                          .with_owner('root')
-                          .with_group('root')
-                          .with_notify('Exec[systemd-reload]')
-                          .with_content(/^# vault systemd unit file/)
-                          .with_content(/^User=vault$/)
-                          .with_content(/^Group=vault$/)
-                          .with_content(/Environment=GOMAXPROCS=3/)
-                          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                          .with_content(/SecureBits=keep-caps/)
-                          .with_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                          .with_content(/CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK/)
-                          .with_content(/NoNewPrivileges=yes/)
-        }
-      end
-      context 'service with non-default options' do
-        let(:params) {{
-                        :bin_dir => '/opt/bin',
-                        :config_dir => '/opt/etc/vault',
-                        :service_options => '-log-level=info',
-                        :user => 'root',
-                        :group => 'admin',
-                        :num_procs => 8,
-                      }}
-        it {
-          is_expected.to contain_file('/etc/systemd/system/vault.service')
-                          .with_mode('0644')
-                          .with_ensure('file')
-                          .with_owner('root')
-                          .with_group('root')
-                          .with_notify('Exec[systemd-reload]')
-                          .with_content(/^# vault systemd unit file/)
-                          .with_content(/^User=root$/)
-                          .with_content(/^Group=admin$/)
-                          .with_content(/Environment=GOMAXPROCS=8/)
-                          .with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
-        }
-      end
-      context 'with mlock disabled' do
-        let(:params) {{
-                        :disable_mlock   => true,
-                        :storage => {
-                          'file' => {
-                            'path' => '/data/vault'
-                          }
-                        },
-                        :listener => {
-                          'tcp' => {
-                            'address'     => '127.0.0.1:8200',
-                            'tls_disable' => 1,
-                          }
-                        }
-                      }}
-        it {
-          is_expected.to contain_file('/etc/systemd/system/vault.service')
-                          .with_mode('0644')
-                          .with_ensure('file')
-                          .with_owner('root')
-                          .with_group('root')
-                          .with_notify('Exec[systemd-reload]')
-                          .with_content(/^# vault systemd unit file/)
-                          .with_content(/^User=vault$/)
-                          .with_content(/^Group=vault$/)
-                          .with_content(%r{^ExecStart=/usr/local/bin/vault server -config=/etc/vault/config.json $})
-                          .without_content(/SecureBits=keep-caps/)
-                          .without_content(/Capabilities=CAP_IPC_LOCK\+ep/)
-                          .with_content(/CapabilityBoundingSet=CAP_SYSLOG/)
-                          .with_content(/NoNewPrivileges=yes/)
-        }
-      end
-      context 'includes systemd reload' do
-        it {
-          is_expected.to contain_exec('systemd-reload')
-                          .with_command('systemctl daemon-reload')
-                          .with_path('/bin:/usr/bin:/sbin:/usr/sbin')
-                          .with_user('root')
-                          .with_refreshonly(true)
-        }
-      end
-      context 'install through repo with default service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => :undef,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-      end
-      context 'install through repo without service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => false,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-      end
-      context 'install through repo with service management' do
-        let(:params) {{
-            :install_method      => 'repo',
-            :manage_service_file => true,
-        }}
-
-        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-      end
-
-      context 'install through archive with default service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => :undef,
-        }}
-
-        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-      end
-      context 'install through archive without service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => false,
-        }}
-
-        it { is_expected.to_not contain_file('/etc/systemd/system/vault.service') }
-      end
-      context 'install through archive with service management' do
-        let(:params) {{
-            :install_method      => 'archive',
-            :manage_service_file => true,
-        }}
-
-        it { is_expected.to contain_file('/etc/systemd/system/vault.service') }
-      end
-    end
-  end
-  context 'Invalid service_provider' do
-    let(:facts) {{
-      :path                      => '/usr/local/bin:/usr/bin:/bin',
-      :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '6',
-      :processorcount            => '3',
-      :architecture              => 'x86_64',
-      :kernel                    => 'Linux',
-      :service_provider          => 'systemd',
-    }}
-    let(:params) {{
-      :service_provider => 'foo',
-    }}
-    context 'fails with a helpful message' do
-      it {
-        expect { should contain_class('vault::config') }
-          .to raise_error(Puppet::Error, /vault::service_provider 'foo' is not valid/)
-      }
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,10 +13,10 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => 'vault')
+    puppet_module_install(source: proj_root, module_name: 'vault')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppet-archive'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppet-archive'), acceptable_exit_codes: [0, 1]
     end
   end
 end


### PR DESCRIPTION
This will take some time. I would like to migrate the existing tests to rspec-puppet-facts. This makes mocking of facts easier. This is needed when we want to use the new structured facts hash.