### PR TITLE
ALways use STRICT_VARIABLES=yes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,7 @@ require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'rubocop/rake_task'
 
-# https://github.com/jsok/puppet-vault/issues/31
-ENV['STRICT_VARIABLES'] = "no" unless Puppet.version.to_f < 4
+ENV['STRICT_VARIABLES'] = "yes"
 
 # These gems aren't always present, for instance
 # on Travis with --without development


### PR DESCRIPTION
Since dropping Puppet 3 support `STRICT_VARIABLES` can now always be set to `yes`.

Fixes #31 