### PR TITLE
puppet-archive: Update to 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppet-archive",
-      "version_requirement": ">= 1.1.2 < 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "camptocamp-systemd",


### PR DESCRIPTION
##### SUMMARY

Puppet 3 support is now dropped, so we can upgrade to the 2.x series: https://github.com/voxpupuli/puppet-archive/blob/master/CHANGELOG.md#v200-2017-08-25

Fixes #109 

##### TESTS/SPECS

Existing specs cover this module's usage of `archive`.