### PR TITLE
Add service_enable and service_ensure parameters

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,8 @@
 fixtures:
-  repositories:
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive: "https://github.com/voxpupuli/puppet-archive"
-    systemd: "https://github.com/camptocamp/puppet-systemd.git"
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    archive: "puppet/archive"
+    systemd: "camptocamp/systemd"
+    file_capability: "stm/file_capability"
   symlinks:
     vault: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -316,7 +316,10 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   Enabled: True
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: True
+
+Style/TrailingCommaInHashLiteral:
   Enabled: True
 
 Style/GlobalVars:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The module will **not** manage any required packages to un-archive, e.g. `unzip`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
 * `version`: The Version of vault to download. default: `0.8.3`
 * `manage_service_file`: Will manage the service file. default: true
+* `manage_file_capabilities`: Will manage file capabilities of the vault binary. default: `true` unless `install_method` is `repo`.
 
 ### Configuration parameters
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `service_name`: Customise the name of the system service
 
+* `service_enable`: Tell the OS to enable or disable the service at system startup
+
+* `service_ensure`: Tell the OS whether the service should be running or stopped
+
 * `service_provider`: Customise the name of the system service provider; this also controls the init configuration files that are installed.
 
 * `service_options`: Extra argument to pass to `vault server`, as per: `vault server --help`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,7 @@ class vault (
   Optional[String] $default_lease_ttl  = $::vault::params::default_lease_ttl,
   Optional[String] $max_lease_ttl      = $::vault::params::max_lease_ttl,
   $disable_mlock                       = $::vault::params::disable_mlock,
+  $manage_file_capabilities            = $::vault::params::manage_file_capabilities,
   $service_options                     = '',
   $num_procs                           = $::vault::params::num_procs,
   $install_method                      = $::vault::params::install_method,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,8 @@ class vault (
   $download_url_base                   = $::vault::params::download_url_base,
   $download_extension                  = $::vault::params::download_extension,
   $service_name                        = $::vault::params::service_name,
+  $service_enable                      = $::vault::params::service_enable,
+  $service_ensure                      = $::vault::params::service_ensure,
   $service_provider                    = $::vault::params::service_provider,
   $manage_service                      = $::vault::params::manage_service,
   $manage_service_file                 = $::vault::params::manage_service_file,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,12 +20,15 @@ class vault::install {
           creates      => $vault_bin,
           before       => File['vault_binary'],
         }
+
+        $_manage_file_capabilities = true
       }
 
     'repo': {
       package { $::vault::package_name:
         ensure  => $::vault::package_ensure,
       }
+      $_manage_file_capabilities = false
     }
 
     default: {
@@ -40,7 +43,7 @@ class vault::install {
     mode  => '0755',
   }
 
-  if !$::vault::disable_mlock {
+  if !$::vault::disable_mlock and pick($::vault::manage_file_capabilities, $_manage_file_capabilities) {
     file_capability { 'vault_binary_capability':
       ensure     => present,
       file       => $vault_bin,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,11 +41,11 @@ class vault::install {
   }
 
   if !$::vault::disable_mlock {
-    exec { 'setcap_vault_binary':
-      command   => "setcap cap_ipc_lock=+ep ${vault_bin}",
-      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
-      subscribe => File['vault_binary'],
-      unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
+    file_capability { 'vault_binary_capability':
+      ensure     => present,
+      file       => $vault_bin,
+      capability => 'cap_ipc_lock=ep',
+      subscribe  => File['vault_binary'],
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class vault::install {
           source       => $::vault::real_download_url,
           cleanup      => true,
           creates      => $vault_bin,
-          before       => File[$vault_bin],
+          before       => File['vault_binary'],
         }
       }
 
@@ -33,16 +33,18 @@ class vault::install {
     }
   }
 
-  file { $vault_bin:
+  file { 'vault_binary':
+    path  =>  $vault_bin,
     owner => 'root',
     group => 'root',
     mode  => '0755',
   }
 
   if !$::vault::disable_mlock {
-    exec { "setcap cap_ipc_lock=+ep ${vault_bin}":
+    exec { 'setcap_vault_binary':
+      command   => "setcap cap_ipc_lock=+ep ${vault_bin}",
       path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
-      subscribe => File[$vault_bin],
+      subscribe => File['vault_binary'],
       unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,9 @@ class vault::params {
 
   $manage_service = true
 
+  $service_enable = true
+  $service_ensure = 'running'
+
   $service_provider = $facts['service_provider']
 
   case $facts['architecture'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,9 @@ class vault::params {
 
   $manage_service = true
 
+  $service_enable = true
+  $service_ensure = 'running'
+
   $service_provider = $facts['service_provider']
 
   case $facts['architecture'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,8 @@ class vault::params {
   $max_lease_ttl      = undef
   $disable_mlock      = undef
 
+  $manage_file_capabilities = undef
+
   $manage_service = true
 
   $service_provider = $facts['service_provider']

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,8 @@
 class vault::service {
   if $::vault::manage_service {
     service { $::vault::service_name:
-      ensure   => running,
-      enable   => true,
+      ensure   => $::vault::service_ensure,
+      enable   => $::vault::service_enable,
       provider => $::vault::service_provider,
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,10 @@
     {
       "name": "camptocamp-systemd",
       "version_requirement": ">= 1.1.1 < 2.0.0"
+    },
+    {
+      "name": "stm-file_capability",
+      "version_requirement": ">=1.0.1 <2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -208,6 +208,22 @@ describe 'vault' do
             with_group('vault')
         }
       end
+
+      context 'when ensuring the service is disabled' do
+        let(:params) do
+          {
+            service_enable: false,
+            service_ensure: 'stopped'
+          }
+        end
+
+        it {
+          is_expected.to contain_service('vault').
+            with_ensure('stopped').
+            with_enable(false)
+        }
+      end
+
       case facts[:os]['family']
       when 'RedHat'
         case facts[:os]['release']['major'].to_i

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -229,6 +229,21 @@ describe 'vault' do
         }
       end
 
+      context 'when ensuring the service is disabled' do
+        let(:params) do
+          {
+            service_enable: false,
+            service_ensure: 'stopped'
+          }
+        end
+
+        it {
+          is_expected.to contain_service('vault').
+            with_ensure('stopped').
+            with_enable(false)
+        }
+      end
+
       case facts[:os]['family']
       when 'RedHat'
         case facts[:os]['release']['major'].to_i

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -77,7 +77,9 @@ describe 'vault' do
 
         it { is_expected.to contain_file('vault_binary').with_mode('0755') }
         it {
-          is_expected.to contain_exec('setcap_vault_binary').
+          is_expected.to contain_file_capability('vault_binary_capability').
+            with_ensure('present').
+            with_capability('cap_ipc_lock=ep').
             that_subscribes_to('File[vault_binary]')
         }
 
@@ -88,7 +90,7 @@ describe 'vault' do
             }
           end
 
-          it { is_expected.not_to contain_exec('setcap_vault_binary') }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
 
           it {
             is_expected.to contain_file('/etc/vault/config.json').
@@ -624,9 +626,8 @@ describe 'vault' do
 
             it { is_expected.to contain_file('vault_binary').with_path('/opt/bin/vault') }
             it {
-              is_expected.to contain_exec('setcap_vault_binary').
-                with_command('setcap cap_ipc_lock=+ep /opt/bin/vault').
-                with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
+              is_expected.to contain_file_capability('vault_binary_capability').
+                with_file('/opt/bin/vault')
             }
 
             it { is_expected.to contain_file('/opt/etc/vault/config.json') }
@@ -839,9 +840,8 @@ describe 'vault' do
         context 'defaults to repo install' do
           it { is_expected.to contain_file('vault_binary').with_path('/bin/vault') }
           it {
-            is_expected.to contain_exec('setcap_vault_binary').
-              with_command('setcap cap_ipc_lock=+ep /bin/vault').
-              with_unless('getcap /bin/vault | grep cap_ipc_lock+ep')
+            is_expected.to contain_file_capability('vault_binary_capability').
+              with_file('/bin/vault')
           }
         end
       end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -76,12 +76,6 @@ describe 'vault' do
         }
 
         it { is_expected.to contain_file('vault_binary').with_mode('0755') }
-        it {
-          is_expected.to contain_file_capability('vault_binary_capability').
-            with_ensure('present').
-            with_capability('cap_ipc_lock=ep').
-            that_subscribes_to('File[vault_binary]')
-        }
 
         context 'when disable mlock' do
           let(:params) do
@@ -143,6 +137,19 @@ describe 'vault' do
                 with_source('http://example.com/vault.zip')
             }
           end
+
+          it {
+            is_expected.to contain_file_capability('vault_binary_capability').
+              with_ensure('present').
+              with_capability('cap_ipc_lock=ep').
+              that_subscribes_to('File[vault_binary]')
+          }
+
+          context 'when not managing file capabilities' do
+            let(:params) { { manage_file_capabilities: false } }
+
+            it { is_expected.not_to contain_file_capability('vault_binary_capability') }
+          end
         end
 
         context 'when installed from package repository' do
@@ -155,6 +162,13 @@ describe 'vault' do
           end
 
           it { is_expected.to contain_package('vault') }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
+
+          context 'when managing file capabilities' do
+            let(:params) { { manage_file_capabilities: true } }
+
+            it { is_expected.to contain_file_capability('vault_binary_capability') }
+          end
         end
       end
 
@@ -839,10 +853,7 @@ describe 'vault' do
       when 'Archlinux'
         context 'defaults to repo install' do
           it { is_expected.to contain_file('vault_binary').with_path('/bin/vault') }
-          it {
-            is_expected.to contain_file_capability('vault_binary_capability').
-              with_file('/bin/vault')
-          }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
         end
       end
     end


### PR DESCRIPTION
##### SUMMARY
This adds the ability to control whether the Vault service is enabled at startup, and whether Puppet should start Vault or leave it stopped.

I needed this for my own use case: we use immutable infrastructure in AWS, so we need to build AMIs that are then thrown into autoscaling groups. The AMIs are built by [Packer](https://www.packer.io/) and we generally do not want services to start during the Packer build, so that no application state is written to the AMI's file system. When a new instance is created and started, we start any services via EC2 user data.

Regardless of the use case, this seemed like a reasonable, common option to add to your otherwise fine module 😄 

##### TESTS/SPECS

Tests were added, but since I don't normally use these kinds of tests, please let me know if this should be coded differently.

The tests run fine except for 5 failures related to Arch Linux that don't seem to have to do with this PR. Additionally I included a minor fix to the Rubocop definition file, since it was exiting immediately and complaining about a deprecated cop.

