### PR TITLE
Manage file caps

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,8 @@
 fixtures:
-  repositories:
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    archive: "https://github.com/voxpupuli/puppet-archive"
-    systemd: "https://github.com/camptocamp/puppet-systemd.git"
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    archive: "puppet/archive"
+    systemd: "camptocamp/systemd"
+    file_capability: "stm/file_capability"
   symlinks:
     vault: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The module will **not** manage any required packages to un-archive, e.g. `unzip`
 * `download_filename`: Filename to (temporarily) save the downloaded zip file, default: `vault.zip`
 * `version`: The Version of vault to download. default: `0.8.3`
 * `manage_service_file`: Will manage the service file. default: true
+* `manage_file_capabilities`: Will manage file capabilities of the vault binary. default: `true` unless `install_method` is `repo`.
 
 ### Configuration parameters
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,7 @@ class vault (
   Optional[String] $default_lease_ttl  = $::vault::params::default_lease_ttl,
   Optional[String] $max_lease_ttl      = $::vault::params::max_lease_ttl,
   $disable_mlock                       = $::vault::params::disable_mlock,
+  $manage_file_capabilities            = $::vault::params::manage_file_capabilities,
   $service_options                     = '',
   $num_procs                           = $::vault::params::num_procs,
   $install_method                      = $::vault::params::install_method,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,12 +20,15 @@ class vault::install {
           creates      => $vault_bin,
           before       => File['vault_binary'],
         }
+
+        $_manage_file_capabilities = true
       }
 
     'repo': {
       package { $::vault::package_name:
         ensure  => $::vault::package_ensure,
       }
+      $_manage_file_capabilities = false
     }
 
     default: {
@@ -40,7 +43,7 @@ class vault::install {
     mode  => '0755',
   }
 
-  if !$::vault::disable_mlock {
+  if !$::vault::disable_mlock and pick($::vault::manage_file_capabilities, $_manage_file_capabilities) {
     file_capability { 'vault_binary_capability':
       ensure     => present,
       file       => $vault_bin,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,11 +41,11 @@ class vault::install {
   }
 
   if !$::vault::disable_mlock {
-    exec { 'setcap_vault_binary':
-      command   => "setcap cap_ipc_lock=+ep ${vault_bin}",
-      path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
-      subscribe => File['vault_binary'],
-      unless    => "getcap ${vault_bin} | grep cap_ipc_lock+ep",
+    file_capability { 'vault_binary_capability':
+      ensure     => present,
+      file       => $vault_bin,
+      capability => 'cap_ipc_lock=ep',
+      subscribe  => File['vault_binary'],
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,8 @@ class vault::params {
   $max_lease_ttl      = undef
   $disable_mlock      = undef
 
+  $manage_file_capabilities = undef
+
   $manage_service = true
 
   $service_provider = $facts['service_provider']

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,10 @@
     {
       "name": "camptocamp-systemd",
       "version_requirement": ">= 1.1.1 < 2.0.0"
+    },
+    {
+      "name": "stm-file_capability",
+      "version_requirement": ">=1.0.1 <2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -77,7 +77,9 @@ describe 'vault' do
 
         it { is_expected.to contain_file('vault_binary').with_mode('0755') }
         it {
-          is_expected.to contain_exec('setcap_vault_binary').
+          is_expected.to contain_file_capability('vault_binary_capability').
+            with_ensure('present').
+            with_capability('cap_ipc_lock=ep').
             that_subscribes_to('File[vault_binary]')
         }
 
@@ -88,7 +90,7 @@ describe 'vault' do
             }
           end
 
-          it { is_expected.not_to contain_exec('setcap_vault_binary') }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
 
           it {
             is_expected.to contain_file('/etc/vault/config.json').
@@ -624,9 +626,8 @@ describe 'vault' do
 
             it { is_expected.to contain_file('vault_binary').with_path('/opt/bin/vault') }
             it {
-              is_expected.to contain_exec('setcap_vault_binary').
-                with_command('setcap cap_ipc_lock=+ep /opt/bin/vault').
-                with_unless('getcap /opt/bin/vault | grep cap_ipc_lock+ep')
+              is_expected.to contain_file_capability('vault_binary_capability').
+                with_file('/opt/bin/vault')
             }
 
             it { is_expected.to contain_file('/opt/etc/vault/config.json') }
@@ -839,9 +840,8 @@ describe 'vault' do
         context 'defaults to repo install' do
           it { is_expected.to contain_file('vault_binary').with_path('/bin/vault') }
           it {
-            is_expected.to contain_exec('setcap_vault_binary').
-              with_command('setcap cap_ipc_lock=+ep /bin/vault').
-              with_unless('getcap /bin/vault | grep cap_ipc_lock+ep')
+            is_expected.to contain_file_capability('vault_binary_capability').
+              with_file('/bin/vault')
           }
         end
       end

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -76,12 +76,6 @@ describe 'vault' do
         }
 
         it { is_expected.to contain_file('vault_binary').with_mode('0755') }
-        it {
-          is_expected.to contain_file_capability('vault_binary_capability').
-            with_ensure('present').
-            with_capability('cap_ipc_lock=ep').
-            that_subscribes_to('File[vault_binary]')
-        }
 
         context 'when disable mlock' do
           let(:params) do
@@ -143,6 +137,19 @@ describe 'vault' do
                 with_source('http://example.com/vault.zip')
             }
           end
+
+          it {
+            is_expected.to contain_file_capability('vault_binary_capability').
+              with_ensure('present').
+              with_capability('cap_ipc_lock=ep').
+              that_subscribes_to('File[vault_binary]')
+          }
+
+          context 'when not managing file capabilities' do
+            let(:params) { { manage_file_capabilities: false } }
+
+            it { is_expected.not_to contain_file_capability('vault_binary_capability') }
+          end
         end
 
         context 'when installed from package repository' do
@@ -155,6 +162,13 @@ describe 'vault' do
           end
 
           it { is_expected.to contain_package('vault') }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
+
+          context 'when managing file capabilities' do
+            let(:params) { { manage_file_capabilities: true } }
+
+            it { is_expected.to contain_file_capability('vault_binary_capability') }
+          end
         end
       end
 
@@ -839,10 +853,7 @@ describe 'vault' do
       when 'Archlinux'
         context 'defaults to repo install' do
           it { is_expected.to contain_file('vault_binary').with_path('/bin/vault') }
-          it {
-            is_expected.to contain_file_capability('vault_binary_capability').
-              with_file('/bin/vault')
-          }
+          it { is_expected.not_to contain_file_capability('vault_binary_capability') }
         end
       end
     end


### PR DESCRIPTION
##### SUMMARY

Use a module to manage file capabilities more succinctly.
Add `manage_file_capabilities` parameter.