### PR TITLE
specs: Use JSON rspec matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :test do
   gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
+  gem 'rspec-json_expectations',                                    :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
   gem 'puppet-lint-version_comparison-check',                       :require => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
+require 'rspec/json_expectations'
 include RspecPuppetFacts


### PR DESCRIPTION
##### SUMMARY

Replace clunky regex comparisons with JSON matchers

Documentation: https://relishapp.com/waterlink/rspec-json-expectations

##### TESTS/SPECS

Updated to use gem.
