### PR TITLE
migrate fixtures to git links

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,8 @@
 fixtures:
-  forge_modules:
-    stdlib: "puppetlabs/stdlib"
-    archive: "puppet/archive"
-    systemd: "camptocamp/systemd"
-    file_capability: "stm/file_capability"
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    archive: "git://github.com/voxpupuli/puppet-archive.git"
+    systemd: "git://github.com/camptocamp/puppet-systemd.git"
+    file_capability: "git://github.com/smoeding/puppet-file_capability.git"
   symlinks:
     vault: "#{source_dir}"


### PR DESCRIPTION
this will pull in fixtures from the master branch and not from the
latest release. This has two benefits. a) getting fixtures is faster. b)
you can test against breaking changes in dependencies before they are
released. This is the current best practice in the Puppet Community.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### TESTS/SPECS

<!---
Pull Requests require passing Travis CI tests.
If you have added new functionality, you **must** include spec tests,
see https://github.com/jsok/puppet-vault/tree/master/spec/classes

If you are adding support for a new OS, then you should also create
acceptance tests, see https://github.com/jsok/puppet-vault/tree/master/spec/acceptance
-->

<!--- Describe how you have tested this change -->
