### PR TITLE
Fixed a misleading variable name in the doc for enabling the ui

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class vault::config {
     'default_lease_ttl' => $::vault::default_lease_ttl,
     'max_lease_ttl'     => $::vault::max_lease_ttl,
     'disable_mlock'     => $::vault::disable_mlock,
-    'ui'                => $::vault::enable_ui,
+    'ui'                => $::vault::ui,
   })
 
   $config_hash = merge($_config_hash, $::vault::extra_config)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,7 +99,7 @@ class vault (
   $version                             = $::vault::params::version,
   $os                                  = $::vault::params::os,
   $arch                                = $::vault::params::arch,
-  Optional[Boolean] $enable_ui         = $::vault::params::enable_ui,
+  Optional[Boolean] $ui                = $::vault::params::ui,
   Hash $extra_config                   = {},
 ) inherits ::vault::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class vault::params {
     },
   }
 
-  $enable_ui          = undef
+  $ui                 = undef
 
   # These should always be undef as they are optional settings that
   # should not be configured unless explicitly declared.

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -207,7 +207,7 @@ describe 'vault' do
       context 'when specifying ui to be true' do
         let(:params) do
           {
-            enable_ui: true
+            ui: true
           }
         end
 


### PR DESCRIPTION
Just a documentation change in order to fix a typo.
