### PR TITLE
Enforce setcap ordering when installing from repo

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,6 +50,10 @@ class vault::install {
       capability => 'cap_ipc_lock=ep',
       subscribe  => File['vault_binary'],
     }
+
+    if $::vault::install_method == 'repo' {
+      Package['vault'] ~> File_capability['vault_binary_capability']
+    }
   }
 
   if $vault::manage_user {

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -198,12 +198,9 @@ describe 'vault' do
 
           context 'when managing file capabilities' do
             let(:params) do
-              {
-                install_method: 'repo',
-                package_name: 'vault',
-                package_ensure: 'installed',
-                manage_file_capabilities: true
-              }
+              super().merge(
+                manage_file_capabilities: true,
+              )
             end
 
             it { is_expected.to contain_file_capability('vault_binary_capability') }

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -197,9 +197,17 @@ describe 'vault' do
           it { is_expected.not_to contain_file_capability('vault_binary_capability') }
 
           context 'when managing file capabilities' do
-            let(:params) { { manage_file_capabilities: true } }
+            let(:params) do
+              {
+                install_method: 'repo',
+                package_name: 'vault',
+                package_ensure: 'installed',
+                manage_file_capabilities: true
+              }
+            end
 
             it { is_expected.to contain_file_capability('vault_binary_capability') }
+            it { is_expected.to contain_package('vault').that_notifies(['File_capability[vault_binary_capability]']) }
           end
         end
       end


### PR DESCRIPTION
##### SUMMARY
Adds a dependency between package installation and setting file
capabilities when using the repo installation method. Without this,
setcap is attempted before the vault binary exists, and causes the
puppet run to fail.

##### TESTS/SPECS
Includes updated spec test that ensures ordering of capability when
enabled an package is installed via repository only.

Change has been validated in production on CentOS 7.5, puppet 4.x

Fixes #92 