### PR TITLE
Add ExecReload to systemd unit file - allow re-read of config files

### DIFF
--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -29,6 +29,7 @@ NoNewPrivileges=yes
 Environment=GOMAXPROCS=<%= scope.lookupvar('vault::num_procs') %>
 ExecStart=<%= scope.lookupvar('vault::bin_dir') %>/vault server -config=<%= scope.lookupvar('vault::config_dir') %>/config.json <%= scope.lookupvar('vault::service_options') %>
 KillSignal=SIGINT
+ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=30s
 Restart=on-failure
 StartLimitInterval=60s


### PR DESCRIPTION
##### SUMMARY

Add support for service reload via systemd. This allows to i.e. reload SSL certificates after they've been updated.
