### PR TITLE
Update systemd template to follow deployment guide

### DIFF
--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -2,13 +2,16 @@
 ###########################################################################################################
 # this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
 # any changes will be overwritten if Puppet is run again
-# This script is originally from: https://github.com/mterron/init-scripts/blob/master/vault.service
+# This script is originally from:
+# https://learn.hashicorp.com/vault/operations/ops-deployment-guide#step-3-configure-systemd
 ###########################################################################################################
 
 [Unit]
-Description=Vault server
-Requires=basic.target network.target
-After=basic.target network.target
+Description="HashiCorp Vault - A tool for managing secrets"
+Documentation=https://www.vaultproject.io/docs/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=<%= scope['vault::config_dir'] %>/config.json
 
 [Service]
 User=<%= scope['vault::user'] %>
@@ -20,13 +23,12 @@ ProtectHome=read-only
 <% # Still require check for :undef for Puppet 3.x -%>
 <% if scope['vault::disable_mlock'] && scope['vault::disable_mlock'] != :undef -%>
 CapabilityBoundingSet=CAP_SYSLOG
-NoNewPrivileges=yes
 <% else -%>
 SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
-NoNewPrivileges=yes
 <% end -%>
+NoNewPrivileges=yes
 Environment=GOMAXPROCS=<%= scope['vault::num_procs'] %>
 ExecStart=<%= scope['vault::bin_dir'] %>/vault server -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
 KillSignal=SIGINT
@@ -34,6 +36,12 @@ TimeoutStopSec=30s
 Restart=on-failure
 StartLimitInterval=60s
 StartLimitBurst=3
+AmbientCapabilities=CAP_IPC_LOCK
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change updates the systemd template to follow the hashicorp vault deployment guide. I had problems with the existing one on Debian 9.

https://learn.hashicorp.com/vault/operations/ops-deployment-guide#step-3-configure-systemd