### PR TITLE
Add Puppet 6, drop Puppet 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -488,9 +488,6 @@ Metrics/AbcSize:
 Metrics/PerceivedComplexity:
   Enabled: False
 
-Lint/UselessAssignment:
-  Enabled: True
-
 Layout/ClosingParenthesisIndentation:
   Enabled: True
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Include:
     - ./**/*.rb
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,35 +7,33 @@ script: bundle exec rake test
 matrix:
   include:
   # RSpec tests
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4"
-  - rvm: 2.4.4
-    env: PUPPET_GEM_VERSION="~> 4" FUTURE=yes
-  - rvm: 2.5.1
-    env: PUPPET_GEM_VERSION="~> 5" DEPLOY_CANDIDATE=yes
+  - rvm: 2.4.5
+    env: PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.5.5
+    env: PUPPET_GEM_VERSION="~> 6" DEPLOY_CANDIDATE=yes
 
   # Beaker tests
   - sudo: required
     services: docker
-    rvm: 2.4.2
+    rvm: 2.5.5
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set="centos-6-x86_64-docker"
     script: bundle exec rake acceptance
     bundler_args: --without development
   - sudo: required
     services: docker
-    rvm: 2.4.2
+    rvm: 2.5.5
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set="centos-7-x86_64-docker"
     script: bundle exec rake acceptance
     bundler_args: --without development
   - sudo: required
     services: docker
-    rvm: 2.4.2
+    rvm: 2.5.5
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set="ubuntu-16.04-x86_64-docker"
     script: bundle exec rake acceptance
     bundler_args: --without development
   - sudo: required
     services: docker
-    rvm: 2.4.2
+    rvm: 2.5.5
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set="ubuntu-18.04-x86_64-docker"
     script: bundle exec rake acceptance
     bundler_args: --without development
@@ -47,4 +45,3 @@ deploy:
   on:
     tags: true
     condition: "$DEPLOY_CANDIDATE = yes"
-

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ group :test do
   gem 'mocha', '>= 1.2.1',                                          :require => false
   gem 'coveralls',                                                  :require => false
   gem 'simplecov-console',                                          :require => false
-  gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
   gem 'parallel_tests',                                             :require => false
   gem 'fakefs',                                                     :require => false
 end
@@ -39,8 +38,7 @@ group :system_tests do
   gem 'beaker-module_install_helper', :require => false
 end
 
-ENV['PUPPET_GEM_VERSION'].nil? ? puppetversion = '~> 5' : puppetversion = ENV['PUPPET_GEM_VERSION'].to_s
+ENV['PUPPET_GEM_VERSION'].nil? ? puppetversion = '~> 6' : puppetversion = ENV['PUPPET_GEM_VERSION'].to_s
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby
-

--- a/metadata.json
+++ b/metadata.json
@@ -15,15 +15,15 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.24.0 < 5.0.0"
+      "version_requirement": ">= 4.24.0 < 6.0.0"
     },
     {
       "name": "puppet-archive",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "camptocamp-systemd",
-      "version_requirement": ">= 1.1.1 < 2.0.0"
+      "version_requirement": ">= 1.1.1 < 3.0.0"
     },
     {
       "name": "stm-file_capability",
@@ -81,7 +81,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
##### SUMMARY

Drop EOL Puppet 3 support.
Start testing against Puppet 6

Also allow puppetlabs-stdlib ~> 5 to be used.


##### TESTS/SPECS

Move CI to use Puppet 5 and 6 and bump ruby to latest point releases.