### PR TITLE
Config file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `config_dir`: Directory the vault configuration will be kept in.
 
+* `config_mode`: Mode of the configuration file (config.json). Defaults to '0750'
+
 * `purge_config_dir`: Whether the `config_dir` should be purged before installing the generated config.
 
 * `install_method`: Supports the values `repo` or `archive`. See [Installation parameters](#installation-parameters).

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,6 +30,7 @@ class vault::config {
     content => to_json_pretty($config_hash),
     owner   => $::vault::user,
     group   => $::vault::group,
+    mode    => $::vault::config_mode,
   }
 
   # If using the file storage then the path must exist and be readable

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,9 @@
 # * `config_dir`
 #   Directory the vault configuration will be kept in.
 #
+# * `config_mode`
+#   Mode of the configuration file (config.json). Defaults to '0750'
+#
 # * `purge_config_dir`
 #   Whether the `config_dir` should be purged before installing the
 #   generated config.
@@ -68,6 +71,7 @@ class vault (
   $manage_group                        = $::vault::params::manage_group,
   $bin_dir                             = $::vault::params::bin_dir,
   $config_dir                          = $::vault::params::config_dir,
+  $config_mode                         = $::vault::params::config_mode,
   $purge_config_dir                    = true,
   $download_url                        = $::vault::params::download_url,
   $download_url_base                   = $::vault::params::download_url_base,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class vault::params {
   $group              = 'vault'
   $manage_group       = true
   $config_dir         = '/etc/vault'
-  $config_mode        = '0750',
+  $config_mode        = '0750'
   $download_url       = undef
   $download_url_base  = 'https://releases.hashicorp.com/vault/'
   $download_extension = 'zip'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class vault::params {
   $group              = 'vault'
   $manage_group       = true
   $config_dir         = '/etc/vault'
+  $config_mode        = '0750',
   $download_url       = undef
   $download_url_base  = 'https://releases.hashicorp.com/vault/'
   $download_extension = 'zip'

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -223,6 +223,16 @@ describe 'vault' do
         }
       end
 
+      context 'when specifying config mode' do
+        let(:params) do
+          {
+            config_mode: '0700'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/vault/config.json').with_mode('0700') }
+      end
+
       context 'when specifying an array of listeners' do
         let(:params) do
           {


### PR DESCRIPTION
##### SUMMARY

Allow customisation of the mode, and putting a secure default.
Vault configuration does need to be hidden a little bit.
When using Consul backend with proper ACLs to protect the vault/
KV path, the Consul ACL token needs to be put in the vault
configuration. File mode defaults to 0644 in puppet, which leave
the token exposed to others, allowing anyone connecting to have
read access to the vault/ path, making Consul ACLs pointless.

Calling it `config_mode` to be consistent with nomad and consul
modules that can be used along with the vault module.

Closes #127 

##### TESTS/SPECS

Spec added to exercise new parameter.