### PR TITLE
Support current version of stm-file_capability.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -273,10 +273,10 @@ Style/EachWithObject:
 Layout/EmptyLineBetweenDefs:
   Enabled: True
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: True
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: True
 
 Layout/IndentationConsistency:

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "stm-file_capability",
-      "version_requirement": ">=1.0.1 <2.0.0"
+      "version_requirement": ">=1.0.1 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Modifies [metadata](https://github.com/jsok/puppet-vault/tree/master/metadata.json) to fix dependency errors when used with the current version of [stm-file_capability](https://github.com/smoeding/puppet-file_capability/blob/master/metadata.json#L3).