### PR TITLE
Remove duplicate TimeoutStopSec in systemd unit file

### DIFF
--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -40,7 +40,6 @@ AmbientCapabilities=CAP_IPC_LOCK
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 RestartSec=5
-TimeoutStopSec=30
 LimitNOFILE=65536
 
 [Install]


### PR DESCRIPTION
TimeoutStopSec is defined twice in the systemd unit file.