### PR TITLE
Service requires config, config file restarts service on change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,6 +33,7 @@ class vault::config {
     owner   => $::vault::user,
     group   => $::vault::group,
     mode    => $::vault::config_mode,
+    notify  => Service[$::vault::service_name]
   }
 
   # If using the file storage then the path must exist and be readable

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ class vault::service {
       ensure   => $::vault::service_ensure,
       enable   => $::vault::service_enable,
       provider => $::vault::service_provider,
+      require  => File["${::vault::config_dir}/config.json"]
     }
   }
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Service does not restart when config file changes.

I noticed this when adding `api_addr` setting, the config file was updated but the service did not restart automatically.

Adding this notify statement ensures the service will be refreshed, the requirement statement ensures the config file exists before starting or refreshing the service.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### TESTS/SPECS

<!---
Pull Requests require passing Travis CI tests.
If you have added new functionality, you **must** include spec tests,
see https://github.com/jsok/puppet-vault/tree/master/spec/classes

If you are adding support for a new OS, then you should also create
acceptance tests, see https://github.com/jsok/puppet-vault/tree/master/spec/acceptance
-->

<!--- Describe how you have tested this change -->
