### PR TITLE
Manage config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `manage_service_file`: Manages the service file regardless of the defaults. Default: See [Installation parameters](#installation-parameters).
 
+* `manage_config_file`: Manages the configuration file. When set to false, `config.json` will not be generated. `manag_storage_dir` is ignored. Default: `true`
+
 ### Installation parameters
 
 #### When `install_method` is `repo`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,22 +4,6 @@
 #
 class vault::config {
 
-  $_config_hash = delete_undef_values({
-    'listener'          => $::vault::listener,
-    'storage'           => $::vault::storage,
-    'ha_storage'        => $::vault::ha_storage,
-    'seal'              => $::vault::seal,
-    'telemetry'         => $::vault::telemetry,
-    'disable_cache'     => $::vault::disable_cache,
-    'default_lease_ttl' => $::vault::default_lease_ttl,
-    'max_lease_ttl'     => $::vault::max_lease_ttl,
-    'disable_mlock'     => $::vault::disable_mlock,
-    'ui'                => $::vault::enable_ui,
-    'api_addr'          => $::vault::api_addr,
-  })
-
-  $config_hash = merge($_config_hash, $::vault::extra_config)
-
   file { $::vault::config_dir:
     ensure  => directory,
     purge   => $::vault::purge_config_dir,
@@ -28,26 +12,45 @@ class vault::config {
     group   => $::vault::group,
   }
 
-  file { "${::vault::config_dir}/config.json":
-    content => to_json_pretty($config_hash),
-    owner   => $::vault::user,
-    group   => $::vault::group,
-    mode    => $::vault::config_mode,
-  }
+  if $::vault::manage_config_file {
 
-  # If using the file storage then the path must exist and be readable
-  # and writable by the vault user, if we have a file path and the
-  # manage_storage_dir attribute is true, then we create it here.
-  #
-  if $::vault::storage['file'] and $::vault::manage_storage_dir {
-    if ! $::vault::storage['file']['path'] {
-      fail('Must provide a path attribute to storage file')
+    $_config_hash = delete_undef_values({
+      'listener'          => $::vault::listener,
+      'storage'           => $::vault::storage,
+      'ha_storage'        => $::vault::ha_storage,
+      'seal'              => $::vault::seal,
+      'telemetry'         => $::vault::telemetry,
+      'disable_cache'     => $::vault::disable_cache,
+      'default_lease_ttl' => $::vault::default_lease_ttl,
+      'max_lease_ttl'     => $::vault::max_lease_ttl,
+      'disable_mlock'     => $::vault::disable_mlock,
+      'ui'                => $::vault::enable_ui,
+      'api_addr'          => $::vault::api_addr,
+    })
+
+    $config_hash = merge($_config_hash, $::vault::extra_config)
+
+    file { "${::vault::config_dir}/config.json":
+      content => to_json_pretty($config_hash),
+      owner   => $::vault::user,
+      group   => $::vault::group,
+      mode    => $::vault::config_mode,
     }
 
-    file { $::vault::storage['file']['path']:
-      ensure => directory,
-      owner  => $::vault::user,
-      group  => $::vault::group,
+    # If using the file storage then the path must exist and be readable
+    # and writable by the vault user, if we have a file path and the
+    # manage_storage_dir attribute is true, then we create it here.
+    #
+    if $::vault::storage['file'] and $::vault::manage_storage_dir {
+      if ! $::vault::storage['file']['path'] {
+        fail('Must provide a path attribute to storage file')
+      }
+
+      file { $::vault::storage['file']['path']:
+        ensure => directory,
+        owner  => $::vault::user,
+        group  => $::vault::group,
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,8 @@ class vault (
   $manage_group                        = $::vault::params::manage_group,
   $bin_dir                             = $::vault::params::bin_dir,
   $config_dir                          = $::vault::params::config_dir,
+
+  $manage_config_file                  = $::vault::params::manage_config_file,
   $config_mode                         = $::vault::params::config_mode,
   $purge_config_dir                    = true,
   $download_url                        = $::vault::params::download_url,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,6 @@ class vault (
   $manage_group                        = $::vault::params::manage_group,
   $bin_dir                             = $::vault::params::bin_dir,
   $config_dir                          = $::vault::params::config_dir,
-
   $manage_config_file                  = $::vault::params::manage_config_file,
   $config_mode                         = $::vault::params::config_mode,
   $purge_config_dir                    = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class vault::params {
   $manage_group       = true
   $config_dir         = '/etc/vault'
   $config_mode        = '0750'
+  $manage_config_file = true
   $download_url       = undef
   $download_url_base  = 'https://releases.hashicorp.com/vault/'
   $download_extension = 'zip'
@@ -23,7 +24,6 @@ class vault::params {
   $manage_download_dir = false
   $download_filename   = 'vault.zip'
 
-  $manage_config_file  = true
   # storage and listener are mandatory, we provide some sensible
   # defaults here
   $storage             = { 'file' => { 'path' => '/var/lib/vault' }}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class vault::params {
   $manage_download_dir = false
   $download_filename   = 'vault.zip'
 
+  $manage_config_file  = true
   # storage and listener are mandatory, we provide some sensible
   # defaults here
   $storage             = { 'file' => { 'path' => '/var/lib/vault' }}

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -317,6 +317,18 @@ describe 'vault' do
         }
       end
 
+      context 'when specifying manage_config_file = false' do
+        let(:params) do
+          {
+            manage_config_file: false,
+          }
+        end
+
+        it {
+          is_expected.not_to contain_file ('/etc/vault/config.json')
+        }
+      end
+
       context 'when ensuring the service is disabled' do
         let(:params) do
           {


### PR DESCRIPTION
##### SUMMARY
Added the option to create the configuration outside of the puppet module. 

I need to install Vault Agent (rather than server). I would like to re-use all the logic to download the binary and create user and group. 

But the service and configuration file being created is not useful. 

I can to set `manage_service_file` and `manage_service` to `false`, but the config file was still being generated.

A better/different solution is to have full support for agent mode. I figure it will take a bit more decision, so I want implement this as a stop gap.

##### TESTS/SPECS

added specs.

I also tested using the updated module and I confirmed that the `config.json` is not being generated.