### PR TITLE
Updated Dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "stm-file_capability",
-      "version_requirement": ">= 1.0.1 < 3.0.0"
+      "version_requirement": ">= 1.0.1 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
##### SUMMARY
Updated module dependency to correct warning being thrown when puppet `module list command` is run on puppet master. Updated dependency maximum versions in the `metadata.json` to correct the warnings and invalid module dependencies.
Please note that I used version numbers exceeding the current version of the dependency to account for future module dependency releases.

This is the warning that I get when I run puppet module list.
```
Warning: Module 'stm-file_capability' (v3.0.0) fails to meet some dependencies:
  'jsok-vault' (v2.2.0) requires 'stm-file_capability' (>= 1.0.1 < 3.0.0)

/etc/puppetlabs/code/environments/production/modules
├── stm-file_capability (v3.0.0)  invalid
```
This pull request fixes this warning. 
