### PR TITLE
Add support for Vault Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `service_provider`: Customise the name of the system service provider; this also controls the init configuration files that are installed.
 
-* `service_options`: Extra argument to pass to `vault server`, as per: `vault server --help`
+* `service_type`: Choose between `server` or `agent` for which mode you want the Vault binary to run as.
+
+* `service_options`: Extra argument to pass to `vault`, e.g., `vault server --help` or `vault agent --help`
 
 * `num_procs`: Sets the `GOMAXPROCS` environment variable, to determine how many CPUs Vault can use. The official Vault Terraform install.sh script sets this to the output of ``nprocs``, with the comment, "Make sure to use all our CPUs, because Vault can block a scheduler thread". Default: number of CPUs on the system, retrieved from the ``processorcount`` fact.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,9 +47,13 @@
 #   Customise the name of the system service provider; this
 #   also controls the init configuration files that are installed.
 #
+# * `service_type`
+#   Choose between `server` or `agent` for which mode you want the
+#   Vault binary to run as.
+#
 # * `service_options`
-#   Extra argument to pass to `vault server`, as per:
-#   `vault server --help`
+#   Extra argument to pass to `vault`, e.g.,
+#   `vault server --help` or `vault agent --help`
 #
 # * `manage_repo`
 #   Configure the upstream HashiCorp repository. Only relevant when $nomad::install_method = 'repo'.
@@ -91,6 +95,7 @@ class vault (
   $service_enable                      = $::vault::params::service_enable,
   $service_ensure                      = $::vault::params::service_ensure,
   $service_provider                    = $::vault::params::service_provider,
+  String $service_type                 = $::vault::params::service_type,
   Boolean $manage_repo                 = $::vault::params::manage_repo,
   $manage_service                      = $::vault::params::manage_service,
   $manage_service_file                 = $::vault::params::manage_service_file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,8 @@ class vault::params {
 
   $service_provider = $facts['service_provider']
 
+  $service_type = 'server'
+
   case $facts['architecture'] {
     'aarch64':        { $arch = 'arm64' }
     /(x86_64|amd64)/: { $arch = 'amd64' }

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -808,6 +808,7 @@ describe 'vault' do
               {
                 bin_dir: '/opt/bin',
                 config_dir: '/opt/etc/vault',
+                service_type: 'agent',
                 service_options: '-log-level=info',
                 user: 'root',
                 group: 'admin'
@@ -830,6 +831,12 @@ describe 'vault' do
             }
             it { is_expected.to contain_user('root') }
             it { is_expected.to contain_group('admin') }
+            context 'contains /etc/init/vault.conf' do
+              it {
+                is_expected.to contain_file('/etc/init.d/vault.conf').
+                  with_content(%r{exec start-stop-daemon -u \$USER -g \$GROUP -p \$PID_FILE -x \$VAULT -S -- agent -config=\$CONFIG $})
+              }
+            end
           end
           context 'install through repo with default service management' do
             let(:params) do
@@ -920,6 +927,7 @@ describe 'vault' do
                 {
                   bin_dir: '/opt/bin',
                   config_dir: '/opt/etc/vault',
+                  service_type: 'agent',
                   service_options: '-log-level=info',
                   user: 'root',
                   group: 'admin',
@@ -937,7 +945,7 @@ describe 'vault' do
                   with_content(%r{^User=root$}).
                   with_content(%r{^Group=admin$}).
                   with_content(%r{Environment=GOMAXPROCS=8}).
-                  with_content(%r{^ExecStart=/opt/bin/vault server -config=/opt/etc/vault/config.json -log-level=info$})
+                  with_content(%r{^ExecStart=/opt/bin/vault agent -config=/opt/etc/vault/config.json -log-level=info$})
               }
             end
             context 'with mlock disabled' do

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# vault - this script manages the vault server
+# vault - this script manages the vault <%= scope['vault::service_type'] %>
 #
 # chkconfig: 3 85 15
 # processname: vault
@@ -18,7 +18,7 @@
 # Required-Stop:  $local_fs $network
 # Default-Start: 3 4 5
 # Default-Stop:  0 1 2 6
-# Short-Description: Manage the vault server
+# Short-Description: Manage the vault <%= scope['vault::service_type'] %>
 ### END INIT INFO
 
 # Source function library.
@@ -51,7 +51,7 @@ start() {
     touch $logfile $pidfile
     chown <%= scope['vault::user'] %> $logfile $pidfile
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
-    daemon --user <%= scope['vault::user'] %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
+    daemon --user <%= scope['vault::user'] %> "{ $exec <%= scope['vault::service_type'] %> -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -30,7 +30,7 @@ CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 <% end -%>
 NoNewPrivileges=yes
 Environment=GOMAXPROCS=<%= scope['vault::num_procs'] %>
-ExecStart=<%= scope['vault::bin_dir'] %>/vault server -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
+ExecStart=<%= scope['vault::bin_dir'] %>/vault <%= scope['vault::service_type'] %> -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
 KillSignal=SIGINT
 TimeoutStopSec=30s
 Restart=on-failure

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -3,7 +3,7 @@
 # this file has been put in place by the jsok/vault Puppet module (https://forge.puppetlabs.com/jsok/vault)
 # any changes will be overwritten if Puppet is run again
 ###########################################################################################################
-description "vault server"
+description "vault <%= scope['vault::service_type'] %>"
 start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]
 
@@ -18,7 +18,7 @@ script
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
     exec >> $LOG_FILE 2>&1
-    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope['vault::service_options'] %>
+    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- <%= scope['vault::service_type'] %> -config=$CONFIG <%= scope['vault::service_options'] %>
 end script
 
 respawn


### PR DESCRIPTION
## SUMMARY

* Add ability to run `vault agent` instead of `vault server`

## TESTS/SPECS

* Add tests to assert that the service command has been changed to start Vault in agent mode