### PR TITLE
add arm64 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class vault::params {
   $service_provider = $facts['service_provider']
 
   case $facts['architecture'] {
+    'aarch64'         { $arch = 'arm64' }
     /(x86_64|amd64)/: { $arch = 'amd64' }
     'i386':           { $arch = '386'   }
     /^arm.*/:         { $arch = 'arm'   }


### PR DESCRIPTION
##### SUMMARY
Adds support for the `arm64`/`aarch64` architecture.

##### TESTS/SPECS
I didn't see any arch-specific tests, but this works fine locally.