### PR TITLE
adding the option to setup the upstream HashiCorp repository

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,13 @@ fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     archive: "git://github.com/voxpupuli/puppet-archive.git"
+    hashi_stack: "https://github.com/voxpupuli/puppet-hashi_stack.git"
     systemd: "git://github.com/camptocamp/puppet-systemd.git"
     file_capability: "git://github.com/smoeding/puppet-file_capability.git"
+    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    yum: "https://github.com/voxpupuli/puppet-yum.git"
+    yumrepo_core:
+      repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
+      puppet_version: ">= 6.0.0"
   symlinks:
     vault: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,10 @@
 # * `service_options`
 #   Extra argument to pass to `vault server`, as per:
 #   `vault server --help`
-
+#
+# * `manage_repo`
+#   Configure the upstream HashiCorp repository. Only relevant when $nomad::install_method = 'repo'.
+#
 # * `manage_service`
 #   Instruct puppet to manage service or not
 #
@@ -88,6 +91,7 @@ class vault (
   $service_enable                      = $::vault::params::service_enable,
   $service_ensure                      = $::vault::params::service_ensure,
   $service_provider                    = $::vault::params::service_provider,
+  Boolean $manage_repo                 = $::vault::params::manage_repo,
   $manage_service                      = $::vault::params::manage_service,
   $manage_service_file                 = $::vault::params::manage_service_file,
   Hash $storage                        = $::vault::params::storage,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,6 +25,9 @@ class vault::install {
       }
 
     'repo': {
+      if $vault::manage_repo{
+        include hashi_stack::repo
+      }
       package { $::vault::package_name:
         ensure  => $::vault::package_ensure,
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,11 +69,13 @@ class vault::params {
       $install_method      = 'repo'
       $bin_dir             = '/bin'
       $manage_service_file = true
+      $manage_repo         = false
     }
     default: {
       $install_method      = 'archive'
       $bin_dir             = '/usr/local/bin'
       $manage_service_file = undef
+      $manage_repo         = true
     }
   }
   $os = downcase($facts['kernel'])

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,10 @@
       "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
+      "name": "puppet/hashi_stack",
+      "version_requirement": ">=1.0.0 <2.0.0"
+    },
+    {
       "name": "camptocamp-systemd",
       "version_requirement": ">= 1.1.1 < 3.0.0"
     },

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -201,6 +201,47 @@ describe 'vault' do
           end
         end
 
+        context "When asked not to manage the repo" do
+          let(:params) {{
+            :manage_repo => false
+          }}
+
+          case facts[:os]['family']
+          when 'Debian'
+            it { should_not contain_apt__source('HashiCorp') }
+          when 'RedHat'
+            it { should_not contain_yumrepo('HashiCorp') }
+          end
+        end
+
+        context "When asked to manage the repo but not to install using repo" do
+          let(:params) {{
+            :install_method => 'archive',
+            :manage_repo => true
+          }}
+
+          case facts[:os]['family']
+          when 'Debian'
+            it { should_not contain_apt__source('HashiCorp') }
+          when 'RedHat'
+            it { should_not contain_yumrepo('HashiCorp') }
+          end
+        end
+
+        context "When asked to manage the repo and to install as repo" do
+          let(:params) {{
+            :install_method => 'repo',
+            :manage_repo => true
+          }}
+
+          case facts[:os]['family']
+          when 'Debian'
+            it { should contain_apt__source('HashiCorp') }
+          when 'RedHat'
+            it { should contain_yumrepo('HashiCorp') }
+          end
+        end
+
         context 'when installed from package repository' do
           let(:params) do
             {


### PR DESCRIPTION
HashiCorp now provides (some) upstream packages, this PR implements the managing of the repo