### PR TITLE
Allow running vault agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Please see [The official documentation](https://www.vaultproject.io/docs/configu
 
 * `service_ensure`: Tell the OS whether the service should be running or stopped
 
+* `service_type`: Tell vault to run as server or agent. Defaults to server.
+
 * `service_provider`: Customise the name of the system service provider; this also controls the init configuration files that are installed.
 
 * `service_options`: Extra argument to pass to `vault server`, as per: `vault server --help`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,9 @@
 # * `manage_group`
 #   Whether or not the module should create the group.
 #
+# # `service_type`
+#   Whether vault should run as server or agent. Defaults to 'server'
+#
 # * `bin_dir`
 #   Directory the vault executable will be installed in.
 #
@@ -53,6 +56,9 @@
 #
 # * `manage_repo`
 #   Configure the upstream HashiCorp repository. Only relevant when $nomad::install_method = 'repo'.
+#
+# # `service_type`
+#   Whether vault should run as server or agent. Defaults to 'server'
 #
 # * `manage_service`
 #   Instruct puppet to manage service or not
@@ -90,6 +96,7 @@ class vault (
   $service_name                        = $::vault::params::service_name,
   $service_enable                      = $::vault::params::service_enable,
   $service_ensure                      = $::vault::params::service_ensure,
+  $service_type                        = $::vault::params::service_type,
   $service_provider                    = $::vault::params::service_provider,
   Boolean $manage_repo                 = $::vault::params::manage_repo,
   $manage_service                      = $::vault::params::manage_service,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,7 @@ class vault::params {
 
   $service_enable = true
   $service_ensure = 'running'
+  $service_type   = 'server'
 
   $service_provider = $facts['service_provider']
 

--- a/templates/vault.initd.erb
+++ b/templates/vault.initd.erb
@@ -51,7 +51,7 @@ start() {
     touch $logfile $pidfile
     chown <%= scope['vault::user'] %> $logfile $pidfile
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
-    daemon --user <%= scope['vault::user'] %> "{ $exec server -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
+    daemon --user <%= scope['vault::user'] %> "{ $exec <%= scope['vault::service_type'] %> -config=$conffile $OPTIONS &>> $logfile & }; echo \$! >| $pidfile"
 
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -30,7 +30,7 @@ CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 <% end -%>
 NoNewPrivileges=yes
 Environment=GOMAXPROCS=<%= scope['vault::num_procs'] %>
-ExecStart=<%= scope['vault::bin_dir'] %>/vault server -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
+ExecStart=<%= scope['vault::bin_dir'] %>/vault <%= scope['vault::service_type'] %> -config=<%= scope['vault::config_dir'] %>/config.json <%= scope['vault::service_options'] %>
 KillSignal=SIGINT
 TimeoutStopSec=30s
 Restart=on-failure

--- a/templates/vault.upstart.erb
+++ b/templates/vault.upstart.erb
@@ -18,7 +18,7 @@ script
     export GOMAXPROCS=${GOMAXPROCS:-<%= scope['vault::num_procs'] %>}
     [ -e /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
     exec >> $LOG_FILE 2>&1
-    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- server -config=$CONFIG <%= scope['vault::service_options'] %>
+    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $VAULT -S -- <%= scope['vault::service_type'] %> -config=$CONFIG <%= scope['vault::service_options'] %>
 end script
 
 respawn


### PR DESCRIPTION
##### SUMMARY

Code written by Karyn Cassio, allows us to run vault as an **agent**, without changing the default functionality.

##### TESTS/SPECS

<!---
Pull Requests require passing Travis CI tests.
If you have added new functionality, you **must** include spec tests,
see https://github.com/jsok/puppet-vault/tree/master/spec/classes

If you are adding support for a new OS, then you should also create
acceptance tests, see https://github.com/jsok/puppet-vault/tree/master/spec/acceptance
-->

We use this code currently in production, use at your own risk.
